### PR TITLE
Tromino link 260114 v0

### DIFF
--- a/lean/dk_math/DkMath/CosmicFormulaTrominoLink.lean
+++ b/lean/dk_math/DkMath/CosmicFormulaTrominoLink.lean
@@ -17,7 +17,7 @@ open DkMath.Polyomino.Tromino
 この定理は、自然数 `x` と `u` に対して次の等式を示します：
 
 $$
-(x + u)^2 - x \cdot (x + 2u) = u^2
+(x + u)^2 - x (x + 2u) = u^2
 $$
 
 ## 証明の概要
@@ -29,7 +29,7 @@ $$
 この定理は、整数の性質を利用して自然数の間の関係を明らかにするものです。
 -/
 theorem cosmic_diff_int (x u : ℕ) :
-    ((x+u : ℤ)^2 - (x : ℤ) * (x + 2*u) ) = (u : ℤ)^2 := by
+    (x+u : ℤ)^2 - (x * (x + 2*u) : ℤ) = (u : ℤ)^2 := by
   -- まず Nat の等式を取り、ℤ に写して整理
   have h : (x+u) * (x+u) = x * (x + 2*u) + u*u :=
     cosmic_area_identity x u
@@ -110,17 +110,17 @@ theorem bridge_tromino_min :
 -/
 theorem bridge_tromino_min_body_ext :
     castShape (body 1 1) = L_tromino := by
-  decide
+  exact bridge_tromino_min.1
 
 /-- `bridge_tromino_min` の第二命題の保険証明（独立した証明として維持） -/
 theorem bridge_tromino_min_gap_ext :
     castShape (gap 1 1) = hole2 := by
-  decide
+  exact bridge_tromino_min.2.1
 
 /-- `bridge_tromino_min` の第三命題の保険証明（独立した証明として維持） -/
 theorem bridge_tromino_min_big_ext :
     castShape (big 1 1) = block2 := by
-  decide
+  exact bridge_tromino_min.2.2
 
 /--
 この定理 `cosmic_is_tromino` は、特定のポリオミノの面積に関する関係を示しています。
@@ -141,7 +141,6 @@ theorem cosmic_is_tromino :
     = DkMath.Polyomino.area (castShape (big 1 1)) := by
   -- bridge_tromino_min の3つの命題を分解して取り出す
   rcases bridge_tromino_min with ⟨h_body, h_gap, h_big⟩
-  
   -- castShape を具体的な形に置き換える
   rw [h_body, h_gap, h_big]
   -- その後、面積計算：


### PR DESCRIPTION
This pull request adds a bridge between the "Cosmic Formula" and "Tromino" concepts by introducing functions and theorems that relate geometric shapes defined over natural numbers to polyominoes defined over integers. The changes include new embedding functions, proofs of injectivity, shape and area preservation lemmas, and several theorems establishing equivalence and area identities between specific shapes in the two frameworks. The code is well-documented with detailed explanations and proof outlines.

**Bridging Cosmic Formula and Tromino Polyominoes:**

* Added `castCell` and `castShape` functions to embed shapes from `ℕ × ℕ` to `ℤ × ℤ`, along with proofs of injectivity and area preservation (`castCell_injective`, `area_castShape`).
* Introduced lemmas and theorems (`mem_castShape`, `bridge_tromino_min`, and its component theorems) showing that specific cosmic formula shapes correspond exactly to standard tromino polyominoes (`L_tromino`, `hole2`, `block2`).

**Area and Identity Theorems:**

* Proved that the sum of the areas of the mapped `body` and `gap` shapes equals the area of the mapped `big` shape, both via explicit shape matching and via area-preserving properties (`cosmic_is_tromino`, `cosmic_is_tromino_alt`).
* Added a new theorem `cosmic_diff_int` relating a quadratic difference identity over integers, with a detailed proof outline.

**Documentation and Proof Robustness:**

* Provided extensive docstrings (in Japanese) explaining the motivation, proof strategies, and engineering rationale for duplicating important theorems for robustness.