### PR TITLE
Exp/cosmic formula 260119 v1

### DIFF
--- a/lean/dk_math/DkMath/CosmicFormula.lean
+++ b/lean/dk_math/DkMath/CosmicFormula.lean
@@ -21,18 +21,18 @@ def cosmic_formula_one_alt (x : ℝ) : ℝ :=
   -- 宇宙式の基本形（トロミノ構造式）
 
 /-- B: 単位宇宙式 Unit Cosmic Formula -/
-def cosmic_formula_u (x u : ℝ) : ℝ :=
+def cosmic_formula_unit (x u : ℝ) : ℝ :=
   (x + u)^2 - x * (x + 2 * u)
   -- u を任意の実数に拡張した形
 
-/-- B':単位宇宙式 Unit Cosmic Formula Alt. -/
-def cosmic_formula_u_alt (x u : ℝ) : ℝ :=
+/-- B': 単位宇宙式 Unit Cosmic Formula Alt. -/
+def cosmic_formula_unit_alt (x u : ℝ) : ℝ :=
   (x + u)^2 - x^2 - 2 * x * u
   -- u を任意の実数に拡張した形（トロミノ構造式）
 
 /-- C: 基本単位宇宙式 Basic Unit Cosmic Formula -/
 def cosmic_formula_unit_one (x : ℝ) : ℝ :=
-  cosmic_formula_u x 1  -- A == B(1)
+  cosmic_formula_unit x 1  -- A == B(1)
   -- 単位宇宙式の基本単位形（定義参照版）
 
 -- 上記の定義の等価性を示す補題群
@@ -41,7 +41,7 @@ def cosmic_formula_unit_one (x : ℝ) : ℝ :=
 lemma cosmic_formula_one_eq_unit_one (x : ℝ) :
     cosmic_formula_one x = cosmic_formula_unit_one x := by
   -- 定義展開で等しい
-  simp [cosmic_formula_one, cosmic_formula_unit_one, cosmic_formula_u]
+  simp [cosmic_formula_one, cosmic_formula_unit_one, cosmic_formula_unit]
 
 /-- 宇宙式 Basic Cosmic Formula とその別形の等価性 -/
 lemma cosmic_formula_one_eq_alt (x : ℝ) :
@@ -50,9 +50,9 @@ lemma cosmic_formula_one_eq_alt (x : ℝ) :
   ring
 
 /-- 単位宇宙式 Unit Cosmic Formula とその別形の等価性 -/
-lemma cosmic_formula_u_eq_alt (x u : ℝ) :
-    cosmic_formula_u x u = cosmic_formula_u_alt x u := by
-  simp [cosmic_formula_u, cosmic_formula_u_alt]
+lemma cosmic_formula_unit_eq_alt (x u : ℝ) :
+    cosmic_formula_unit x u = cosmic_formula_unit_alt x u := by
+  simp [cosmic_formula_unit, cosmic_formula_unit_alt]
   ring
 
 -- Additional definitions and theorems related to the cosmic formula can be added here.
@@ -66,13 +66,13 @@ lemma cosmic_formula_u_eq_alt (x u : ℝ) :
 example : ∀ x : ℝ, cosmic_formula_one x = 1 := cosmic_formula_one_theorem
 
 -- 単位宇宙式の恒等式を証明する例
-@[simp] theorem cosmic_formula_unit_theorem (x u : ℝ) : cosmic_formula_u x u = u^2 :=
+@[simp] theorem cosmic_formula_unit_theorem (x u : ℝ) : cosmic_formula_unit x u = u^2 :=
   by
-    simp [cosmic_formula_u]
+    simp [cosmic_formula_unit]
     ring
 
 -- test
-example : ∀ x u : ℝ, cosmic_formula_u x u = u^2 := cosmic_formula_unit_theorem
+example : ∀ x u : ℝ, cosmic_formula_unit x u = u^2 := cosmic_formula_unit_theorem
 
 /-- 全ての関数 f(x) において 1 を返す -/
 theorem cosmic_formula_one_func :
@@ -81,9 +81,9 @@ theorem cosmic_formula_one_func :
   simp [cosmic_formula_one_theorem]
 
 /-- 全ての関数 f(x), g(u) において g(u) ↦ (g(u))^2 を返す -/
-theorem cosmic_formula_u_func :
+theorem cosmic_formula_unit_func :
     ∀ (f : ℝ → ℝ) (g : ℝ → ℝ) (x u : ℝ),
-      cosmic_formula_u (f x) (g u) = (g u)^2 := by
+      cosmic_formula_unit (f x) (g u) = (g u)^2 := by
   intro f g x u
   simp [cosmic_formula_unit_theorem]
 
@@ -95,9 +95,9 @@ theorem cosmic_formula_one_add :
   norm_num
 
 /-- 単位宇宙式による異なる単位の加法 -/
-theorem cosmic_formula_u_add :
+theorem cosmic_formula_unit_add :
     ∀ x y u v : ℝ,
-      cosmic_formula_u x u + cosmic_formula_u y v = u^2 + v^2 := by
+      cosmic_formula_unit x u + cosmic_formula_unit y v = u^2 + v^2 := by
   intro x y u v
   simp only [cosmic_formula_unit_theorem]
 
@@ -111,25 +111,25 @@ theorem cosmic_formula_one_func_add :
 
 /-- 単位宇宙式による異なる単位の加法（関数版）
   ⟨ f(x), g(u) ⟩ + ⟨ f(y), g(v) ⟩ = (g(u))^2 + (g(v))^2 -/
-theorem cosmic_formula_u_func_add :
+theorem cosmic_formula_unit_func_add :
     ∀ (f : ℝ → ℝ) (g : ℝ → ℝ) (x y u v : ℝ),
-      cosmic_formula_u (f x) (g u) + cosmic_formula_u (f y) (g v) = (g u)^2 + (g v)^2 := by
+      cosmic_formula_unit (f x) (g u) + cosmic_formula_unit (f y) (g v) = (g u)^2 + (g v)^2 := by
   intro f g x y u v
   simp only [cosmic_formula_unit_theorem]
 
 -- More theorems and proofs can be added here.
 
 -- 「差」版（減法が要るので CommRing）
-def cosmic_formula_u_sub {R : Type*} [CommRing R] (x u : R) : R :=
+def cosmic_formula_unit_sub {R : Type*} [CommRing R] (x u : R) : R :=
   (x + u)^2 - x * (x + 2 * u)
 
 @[simp] theorem cosmic_formula_unit_sub_eq {R : Type*} [CommRing R] (x u : R) :
-    cosmic_formula_u_sub x u = u^2 := by
-  unfold cosmic_formula_u_sub
+    cosmic_formula_unit_sub x u = u^2 := by
+  unfold cosmic_formula_unit_sub
   ring
 
 @[simp] theorem cosmic_formula_one_sub_eq {R : Type*} [CommRing R] (x : R) :
-    cosmic_formula_u_sub x (1 : R) = 1 := by
+    cosmic_formula_unit_sub x (1 : R) = 1 := by
   simp [cosmic_formula_unit_sub_eq]
 
 -- 「加法」版（こちらが宇宙式の素顔。減法なしで済むので CommSemiring まで下げられる）
@@ -156,51 +156,51 @@ theorem cosmic_formula_sub_from_add {R : Type*} [CommRing R] (x u : R) :
 /--
 Equality of the two variants of the cosmic formula.
 
-For all real `x` and `u`, the convenience definition `cosmic_formula_u x u`
-coincides with the alternative/subscript definition `cosmic_formula_u_sub x u`.
+For all real `x` and `u`, the convenience definition `cosmic_formula_unit x u`
+coincides with the alternative/subscript definition `cosmic_formula_unit_sub x u`.
 The proof proceeds by simplifying/unfolding both definitions.
 -/
-lemma cosmic_formula_u_eq_sub (x u : ℝ) :
-    cosmic_formula_u x u = cosmic_formula_u_sub x u := by
-  simp [cosmic_formula_u, cosmic_formula_u_sub]
+lemma cosmic_formula_unit_eq_sub (x u : ℝ) :
+    cosmic_formula_unit x u = cosmic_formula_unit_sub x u := by
+  simp [cosmic_formula_unit, cosmic_formula_unit_sub]
 
 /-- For any real `x`, `cosmic_formula_one x` is definitionally equal to
-`cosmic_formula_u_sub x 1`. This lemma connects the specialized
-`cosmic_formula_one` with the more general `cosmic_formula_u_sub`
-instantiated at `u = 1`. It is intended as a `@[simp]` lemma so that
-`cosmic_formula_one` can be simplified to the `u_sub` form. -/
+`cosmic_formula_unit_sub x 1`. This lemma connects the specialized
+`cosmic_formula_one` with the more general `cosmic_formula_unit_sub`
+instantiated at `u = 1`. It can be used to rewrite `cosmic_formula_one`
+into the more general `unit_sub` form when convenient. -/
 lemma cosmic_formula_one_eq_sub (x : ℝ) :
-    cosmic_formula_one x = cosmic_formula_u_sub x (1:ℝ) := by
-  simp [cosmic_formula_one, cosmic_formula_u_sub]
+    cosmic_formula_one x = cosmic_formula_unit_sub x (1:ℝ) := by
+  simp [cosmic_formula_one, cosmic_formula_unit_sub]
 
 -- Additional lemmas and theorems can be added here.
 
-/-- cosmic_formula_u_sub_u0
+/-- cosmic_formula_unit_sub_u0
 
 For any commutative ring R and element x : R, substituting 0 into the second argument
-of `cosmic_formula_u_sub` yields 0:
+of `cosmic_formula_unit_sub` yields 0:
 
-  cosmic_formula_u_sub x (0 : R) = 0
+  cosmic_formula_unit_sub x (0 : R) = 0
 
 Parameters
 - `R` : a type equipped with a `CommRing` instance
 - `x` : an element of `R`
 
-Proof sketch: unfold the definition of `cosmic_formula_u_sub` and finish with `ring`.
+Proof sketch: unfold the definition of `cosmic_formula_unit_sub` and finish with `ring`.
 -/
-@[simp] lemma cosmic_formula_u_sub_u0 {R : Type*} [CommRing R] (x : R) :
-    cosmic_formula_u_sub x (0:R) = 0 := by
-  unfold cosmic_formula_u_sub
+@[simp] lemma cosmic_formula_unit_sub_u0 {R : Type*} [CommRing R] (x : R) :
+    cosmic_formula_unit_sub x (0:R) = 0 := by
+  unfold cosmic_formula_unit_sub
   ring
 
 /--
 For any commutative ring R and element `u : R`, evaluating
-`cosmic_formula_u_sub` at `x0 = 0` yields `u^2`. The equality follows
-by unfolding the definition of `cosmic_formula_u_sub` and simplifying.
+`cosmic_formula_unit_sub` at `x0 = 0` yields `u^2`. The equality follows
+by unfolding the definition of `cosmic_formula_unit_sub` and simplifying.
 -/
-@[simp] lemma cosmic_formula_u_sub_x0 {R : Type*} [CommRing R] (u : R) :
-    cosmic_formula_u_sub (0:R) u = u^2 := by
-  simp [cosmic_formula_u_sub]
+@[simp] lemma cosmic_formula_unit_sub_x0 {R : Type*} [CommRing R] (u : R) :
+    cosmic_formula_unit_sub (0:R) u = u^2 := by
+  simp [cosmic_formula_unit_sub]
 
 -- 加法版でも
 /-- If the parameter `x` is `0`, then `N` evaluates to `0` for any element `u` of a commutative


### PR DESCRIPTION
This pull request significantly expands the `CosmicFormula` namespace in `CosmicFormula.lean` by adding alternative definitions, equivalence lemmas, and a suite of new theorems demonstrating the relationships and properties of the cosmic formulas. It also improves naming consistency and adds more comprehensive documentation to each definition and theorem. Additionally, some lemmas have been untagged from `@[simp]` to give more control over simplification in proofs.

**Key changes:**

**1. New and alternative definitions:**
- Added alternative forms for the basic and unit cosmic formulas: `cosmic_formula_one_alt` and `cosmic_formula_u_alt`, as well as a convenience definition `cosmic_formula_unit_one` and corresponding documentation.

**2. Equivalence lemmas between definitions:**
- Introduced lemmas proving the equivalence between the original and alternative forms: `cosmic_formula_one_eq_alt`, `cosmic_formula_u_eq_alt`, and between the basic and unit forms: `cosmic_formula_one_eq_unit_one`.

**3. Expanded theorem suite:**
- Added new theorems showing properties such as function application, addition, and function addition for both the basic and unit cosmic formulas (e.g., `cosmic_formula_one_func`, `cosmic_formula_u_func`, `cosmic_formula_one_add`, `cosmic_formula_u_add`, etc.).

**4. Naming and documentation improvements:**
- Improved the clarity of docstrings and comments, added explicit labels (A, B, C, etc.) to definitions, and renamed theorems for consistency (e.g., `cosmic_formula_one_theorem`, `cosmic_formula_unit_theorem`).

**5. Simplification attribute adjustments:**
- Removed the `@[simp]` attribute from the lemmas `cosmic_formula_u_eq_sub` and `cosmic_formula_one_eq_sub` to avoid automatic simplification in all cases, giving more manual control in proofs. [[1]](diffhunk://#diff-04fdbf5617d2f2d23fc801c4662642e3ee8e940d3fe37ca6881f365db6af1579L84-R163) [[2]](diffhunk://#diff-04fdbf5617d2f2d23fc801c4662642e3ee8e940d3fe37ca6881f365db6af1579L93-R172)This pull request significantly expands and refines the `CosmicFormula` module in `lean/dk_math/DkMath/CosmicFormula.lean`. It introduces alternative definitions for core formulas, adds a series of equivalence lemmas between these forms, and provides new theorems about their properties and behaviors—especially regarding function application and addition. It also improves naming consistency and annotation for key theorems, and removes some unnecessary `@[simp]` attributes from certain lemmas.

**Key changes include:**

**1. New and Alternative Definitions:**
- Added alternative forms for both the basic (`cosmic_formula_one_alt`) and unit (`cosmic_formula_u_alt`) cosmic formulas, as well as a convenience wrapper (`cosmic_formula_unit_one`).

**2. Equivalence Lemmas:**
- Introduced lemmas showing the equivalence between the original and alternative forms of the formulas, as well as between the basic and unit forms.

**3. Theorem Expansion and Generalization:**
- Added new theorems demonstrating properties such as:
  - The formulas' behavior under function application.
  - Additive properties for both the basic and unit formulas, including function versions.
  - Provided explicit `@[simp]` attributes for main theorems, and improved naming for clarity (e.g., `cosmic_formula_one_theorem`, `cosmic_formula_unit_theorem`).

**4. Naming and Annotation Improvements:**
- Improved theorem and lemma naming for clarity and consistency (e.g., `cosmic_formula_unit_theorem` instead of `example_theorem_u`).
- Added or removed `@[simp]` attributes as appropriate for simplification lemmas. [[1]](diffhunk://#diff-04fdbf5617d2f2d23fc801c4662642e3ee8e940d3fe37ca6881f365db6af1579L13-R133) [[2]](diffhunk://#diff-04fdbf5617d2f2d23fc801c4662642e3ee8e940d3fe37ca6881f365db6af1579L84-R163) [[3]](diffhunk://#diff-04fdbf5617d2f2d23fc801c4662642e3ee8e940d3fe37ca6881f365db6af1579L93-R172)

**5. Lemma Attribute Adjustments:**
- Removed unnecessary `@[simp]` attributes from `cosmic_formula_u_eq_sub` and `cosmic_formula_one_eq_sub` to avoid over-aggressive simplification in proofs. [[1]](diffhunk://#diff-04fdbf5617d2f2d23fc801c4662642e3ee8e940d3fe37ca6881f365db6af1579L84-R163) [[2]](diffhunk://#diff-04fdbf5617d2f2d23fc801c4662642e3ee8e940d3fe37ca6881f365db6af1579L93-R172)