### PR TITLE
Hackathon: publish GN5/FLT5 entrypoints and source exposition

### DIFF
--- a/lean/dk_math/DkMath/FLT/Five.lean
+++ b/lean/dk_math/DkMath/FLT/Five.lean
@@ -9,10 +9,16 @@ import DkMath.FLT.Five.Main
 #print "file: DkMath.FLT.Five"
 
 /-!
-# FLT5 / GN5 experiment tower
+# GN5 / FLT5 exponent-five development
 
-This module is intentionally local and partially duplicative. The first goal is to
-obtain Lean-certified exponent-five facts with an explicit clean-channel contract.
+The public endpoint `DkMath.FLT.Five.fermatFive_no_positive_solution` proves that
+positive natural numbers do not satisfy `x^5 + y^5 = z^5`. Its proof passes
+through GN5 identities, five-adic factor splitting, arithmetic in the direct
+coordinate golden order, unit classes, and a strict zero-sector descent.
+
+The scope is exponent five over positive natural numbers. No claim is made here
+about the general Fermat theorem, historical novelty, external peer review, or
+formal identification of `GoldenInt` with a field-level ring of integers.
 
 `Standalone.lean` is deliberately not imported here: it must remain a Mathlib-only
 single-file seed for Lean Comparator Live.

--- a/lean/dk_math/DkMath/FLT/Five/Basic.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Basic.lean
@@ -10,11 +10,22 @@ import Mathlib
 
 namespace DkMath.FLT.Five
 
-/-- The exponent-five Fermat equation. -/
+/-!
+# Positive natural-number data for exponent five
+
+This module fixes the exact scope of the local development: positive natural numbers
+satisfying `x^5 + y^5 = z^5`.  `CounterexamplePack` is the primitive input used by the
+later gap, five-adic, and quadratic-order reductions.  It records coprimality only for
+the two left-hand bases; the other coprimality facts are derived from the equation.
+-/
+
+/-- The equation `x^5 + y^5 = z^5` over natural numbers.  Positivity is deliberately
+kept outside this definition and supplied by `CounterexamplePack` or `FLT5Target`. -/
 def Fermat5Equation (x y z : ℕ) : Prop :=
   x ^ 5 + y ^ 5 = z ^ 5
 
-/-- Positive coprime data for a candidate exponent-five counterexample. -/
+/-- A positive primitive candidate for the exponent-five equation.  The condition
+`Coprime x y` is the normalization needed by every subsequent local factorization. -/
 structure CounterexamplePack (x y z : ℕ) : Prop where
   hx : 0 < x
   hy : 0 < y

--- a/lean/dk_math/DkMath/FLT/Five/BranchA.lean
+++ b/lean/dk_math/DkMath/FLT/Five/BranchA.lean
@@ -10,17 +10,22 @@ import DkMath.FLT.Five.Basic
 
 namespace DkMath.FLT.Five
 
+/-!
+# Exceptional five-divisible gap interface
+
+`BranchACondition y z` names the exceptional orientation `5 | z-y`.  In the completed
+tower this branch is not attacked by the early clean-channel argument.  Instead,
+`SignedBranchA` routes both the difference and sum orientations into a common exact
+five-adic packet, and the later golden-order descent supplies the refuter contract.
+-/
+
 /-- The exponent-five branch in which the exponent divides the natural-number gap. -/
 def BranchACondition (y z : ℕ) : Prop :=
   5 ∣ z - y
 
-/-- Contract for a future dedicated five-adic Branch-A refuter. -/
+/-- Reusable receiver for the completed signed five-adic and golden-order refutation
+of a primitive candidate whose natural gap is divisible by five. -/
 abbrev BranchARefuter : Prop :=
   ∀ {x y z : ℕ}, CounterexamplePack x y z → BranchACondition y z → False
-
-/-!
-The first Branch-A checkpoint will extract the five-adic normal form implied by
-`5 ∣ z-y`.  It will not assume that the normal form is already contradictory.
--/
 
 end DkMath.FLT.Five

--- a/lean/dk_math/DkMath/FLT/Five/BranchB.lean
+++ b/lean/dk_math/DkMath/FLT/Five/BranchB.lean
@@ -10,6 +10,14 @@ import DkMath.FLT.Five.CleanChannel
 
 namespace DkMath.FLT.Five
 
+/-!
+# The gap-times-cyclotomic body
+
+For `g = z-y`, `Body5 g y` is the exact product `g * GN5 g y` representing
+`z^5-y^5`.  A Fermat-five candidate identifies this body with `x^5`; a clean prime
+channel then contradicts perfect fifth-power divisibility.
+-/
+
 /-- The exponent-five body in local gap coordinates. -/
 def Body5 (g y : ℕ) : ℕ :=
   g * GN5 g y

--- a/lean/dk_math/DkMath/FLT/Five/CleanChannel.lean
+++ b/lean/dk_math/DkMath/FLT/Five/CleanChannel.lean
@@ -10,7 +10,19 @@ import DkMath.FLT.Five.GN5
 
 namespace DkMath.FLT.Five
 
-/-- A prime channel that enters `GN5`, avoids the gap, and does not lift to its square. -/
+/-!
+# Local valuation-one obstructions
+
+A `CleanGN5Channel g y q` is a prime divisor of the cyclotomic factor which does not
+divide the gap and occurs only to its first power.  Hence `q` divides
+`g * GN5 g y`, while `q^2` does not.  This is incompatible with a fifth power.
+
+The module gives the direct square-divisibility contradiction.  `Valuation.lean`
+repackages the same obstruction as the incompatible bounds `v_q >= 5` and `v_q <= 1`.
+-/
+
+/-- A prime occurring with local valuation exactly one in the residual and valuation
+zero in the gap.  The fields are intentionally explicit so providers can be audited. -/
 structure CleanGN5Channel (g y q : ℕ) : Prop where
   prime : Nat.Prime q
   dvd_GN5 : q ∣ GN5 g y

--- a/lean/dk_math/DkMath/FLT/Five/GN5.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GN5.lean
@@ -10,13 +10,50 @@ import DkMath.FLT.Five.Basic
 
 namespace DkMath.FLT.Five
 
-/-- The exponent-five GN polynomial in gap/body coordinates. -/
+/-!
+# The homogeneous fifth cyclotomic factor in gap coordinates
+
+Write `z = g + y`.  The polynomial `GN5 g y` is the usual quotient
+
+`(z^5 - y^5) / (z - y) = z^4 + z^3*y + z^2*y^2 + z*y^3 + y^4`
+
+after substituting `z = g + y`.  Thus `(g+y)^5-y^5 = g * GN5 g y`.  The two
+decomposition theorems below expose its reductions modulo the gap and modulo five;
+these explain why five is the only exceptional common prime in the primitive route.
+-/
+
+/-- The homogeneous fifth cyclotomic quotient expressed in the local coordinates
+`z = g + y`. -/
 def GN5 (g y : ℕ) : ℕ :=
   g ^ 4
     + 5 * g ^ 3 * y
     + 10 * g ^ 2 * y ^ 2
     + 10 * g * y ^ 3
     + 5 * y ^ 4
+
+/-- Identification of `GN5` with the standard homogeneous fifth cyclotomic factor. -/
+theorem GN5_eq_homogeneous_cyclotomic (g y : ℕ) :
+    GN5 g y =
+      (g + y) ^ 4 + (g + y) ^ 3 * y + (g + y) ^ 2 * y ^ 2 +
+        (g + y) * y ^ 3 + y ^ 4 := by
+  unfold GN5
+  ring
+
+/-- Gap decomposition: `GN5(g,y) ≡ 5*y^4 (mod g)`. -/
+theorem GN5_eq_gap_mul_add_five_mul_y_pow_four (g y : ℕ) :
+    GN5 g y =
+      g * (g ^ 3 + 5 * g ^ 2 * y + 10 * g * y ^ 2 + 10 * y ^ 3) +
+        5 * y ^ 4 := by
+  unfold GN5
+  ring
+
+/-- Five-adic decomposition: `GN5(g,y) ≡ g^4 (mod 5)`. -/
+theorem GN5_eq_g_pow_four_add_five_mul (g y : ℕ) :
+    GN5 g y =
+      g ^ 4 + 5 * (g ^ 3 * y + 2 * g ^ 2 * y ^ 2 +
+        2 * g * y ^ 3 + y ^ 4) := by
+  unfold GN5
+  ring
 
 /-- The fifth-power body decomposition before subtraction. -/
 theorem add_pow_five_eq_add_mul_GN5 (g y : ℕ) :

--- a/lean/dk_math/DkMath/FLT/Five/GoldenCoprimeFactor.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GoldenCoprimeFactor.lean
@@ -11,6 +11,15 @@ import DkMath.FLT.Five.SignedGoldenFifthPower
 
 namespace DkMath.FLT.Five
 
+/-!
+# Coprime factors of a fifth power
+
+The norm-Euclidean structure supplies a gcd monoid on `GoldenInt`.  Consequently, if
+`x*y=z^5` and every common divisor of `x,y` is a unit, unique factorization gives
+`x=epsilon*gamma^5` for a unit `epsilon`.  This is the algebraic extraction consumed by
+the finite unit-class layer; it introduces no FLT-specific assumption.
+-/
+
 /-- The explicit golden-unit predicate agrees with the standard ring predicate. -/
 theorem goldenUnit_iff_isUnit {x : GoldenInt} : GoldenUnit x ↔ IsUnit x := by
   constructor
@@ -38,7 +47,7 @@ theorem goldenCoprimeFactorOfFifthPower : GoldenCoprimeFactorOfFifthPower := by
   refine ⟨(u : GoldenInt), gamma, goldenUnit_iff_isUnit.mpr u.isUnit, ?_⟩
   simpa [golden_mul_eq, golden_pow_eq, mul_comm] using hu.symm
 
-/-- The cp-004f signed golden core now follows without an extra factorization axiom. -/
+/-- Every ramifier-stripped FLT5 packet therefore factors as a unit times a fifth power. -/
 theorem signedGoldenFifthPowerUpToUnitCore : SignedGoldenFifthPowerUpToUnitCore :=
   signedGoldenFifthPowerUpToUnitCore_of_coprimeFactor
     goldenCoprimeFactorOfFifthPower

--- a/lean/dk_math/DkMath/FLT/Five/GoldenDivisibility.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GoldenDivisibility.lean
@@ -10,6 +10,16 @@ import DkMath.FLT.Five.GoldenOrder
 
 namespace DkMath.FLT.Five
 
+/-!
+# Divisibility, units, and relative primality in `ℤ[φ]`
+
+This module connects the explicit coordinate vocabulary to ordinary commutative-ring
+divisibility.  Multiplicativity of the norm sends golden divisibility to integer
+divisibility; norm `±1` characterizes the units used later.  `GoldenRelPrime x y` is
+the Bézout-free statement that every common divisor is a unit, tailored to the
+element/conjugate factorization arising from the norm.
+-/
+
 /-- Explicit golden divisibility, definitionally compatible with ring divisibility. -/
 def GoldenDivides (d x : GoldenInt) : Prop :=
   ∃ q : GoldenInt, x = goldenMul d q
@@ -76,7 +86,8 @@ theorem goldenNorm_pow (x : GoldenInt) (n : ℕ) :
       change goldenNorm (goldenMul (x ^ n) x) = _
       rw [goldenNorm_mul, ih, pow_succ]
 
-/-- A two-sided unit for the explicit golden-order multiplication API. -/
+/-- A two-sided unit in the coordinate order.  Later theorems identify this predicate
+with Mathlib's `IsUnit` and with norm `±1`. -/
 def GoldenUnit (epsilon : GoldenInt) : Prop :=
   ∃ eta : GoldenInt,
     goldenMul epsilon eta = goldenOne ∧ goldenMul eta epsilon = goldenOne
@@ -152,7 +163,8 @@ theorem goldenUnit_pow {x : GoldenInt} (hx : GoldenUnit x) (n : ℕ) :
   | zero => exact goldenUnit_one
   | succ n ih => exact goldenUnit_mul ih hx
 
-/-- Relatively prime means that every common golden divisor is a unit. -/
+/-- Relative primality expressed by saying that every common divisor is a unit, hence
+has norm `±1`. -/
 def GoldenRelPrime (x y : GoldenInt) : Prop :=
   ∀ d : GoldenInt, GoldenDivides d x → GoldenDivides d y → GoldenUnit d
 

--- a/lean/dk_math/DkMath/FLT/Five/GoldenEuclidean.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GoldenEuclidean.lean
@@ -12,6 +12,17 @@ import Mathlib.RingTheory.EuclideanDomain
 
 namespace DkMath.FLT.Five
 
+/-!
+# Norm-Euclidean division in `ℤ[φ]`
+
+The rational quotient of two golden integers is rounded in both coordinates.  On the
+rounding cell `|u|,|v| <= 1/2`, the norm form satisfies
+`|u^2+u*v-v^2| <= 5/16 < 1`.  After clearing the denominator this gives a remainder
+whose absolute norm is strictly smaller than the divisor's.  The final instance makes
+`GoldenInt` a `EuclideanDomain`; `GoldenCoprimeFactor` then uses the resulting gcd
+theory to split coprime factors of a fifth power.
+-/
+
 /-- Rational coordinates in the basis `1, phi`. -/
 abbrev GoldenRat := ℚ × ℚ
 
@@ -212,7 +223,8 @@ theorem exists_golden_quotient_remainder
   · simp [goldenRemainder, golden_mul_eq]
   · exact Or.inr (golden_remainder_size_lt x hy)
 
-/-- The golden integer ring is Euclidean for the absolute golden norm. -/
+/-- Euclidean division for the absolute norm, with well-founded measure
+`natAbs (goldenNorm x)`. -/
 noncomputable instance goldenEuclideanDomain : EuclideanDomain GoldenInt where
   quotient := goldenQuotient
   quotient_zero := goldenQuotient_zero

--- a/lean/dk_math/DkMath/FLT/Five/GoldenFifthPowerCoordinates.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GoldenFifthPowerCoordinates.lean
@@ -10,6 +10,16 @@ import DkMath.FLT.Five.SignedGoldenFifthPower
 
 namespace DkMath.FLT.Five
 
+/-!
+# Fifth-power coordinates and unit sectors
+
+For `gamma=p+q*φ`, this module names the two coordinate polynomials of `gamma^5`.
+It then computes the second coordinate after multiplication by the five representatives
+`1,φ,...,φ^4`.  These formulas turn unit classes modulo fifth powers into five explicit
+arithmetic sectors; “sector” here is purely an algebraic unit class, not a geometric or
+analytic region.
+-/
+
 /-- First-coordinate polynomial of `(p + q*phi)^5`. -/
 def goldenFifthFstPoly (p q : ℤ) : ℤ :=
   p ^ 5 + 10 * p ^ 3 * q ^ 2 + 10 * p ^ 2 * q ^ 3 +
@@ -20,11 +30,13 @@ def goldenFifthSndPoly (p q : ℤ) : ℤ :=
   5 * q * (p ^ 4 + 2 * p ^ 3 * q + 4 * p ^ 2 * q ^ 2 +
     3 * p * q ^ 3 + q ^ 4)
 
+/-- Exact first coordinate of `gamma^5`. -/
 theorem goldenPow_five_fst (gamma : GoldenInt) :
     (goldenPow gamma 5).fst = goldenFifthFstPoly gamma.fst gamma.snd := by
   simp [goldenPow, goldenMul, goldenOne, goldenFifthFstPoly]
   ring
 
+/-- Exact second coordinate of `gamma^5`; it contains the visible factor `5*q`. -/
 theorem goldenPow_five_snd (gamma : GoldenInt) :
     (goldenPow gamma 5).snd = goldenFifthSndPoly gamma.fst gamma.snd := by
   simp [goldenPow, goldenMul, goldenOne, goldenFifthSndPoly]

--- a/lean/dk_math/DkMath/FLT/Five/GoldenOrder.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GoldenOrder.lean
@@ -11,7 +11,25 @@ import Mathlib.NumberTheory.Zsqrtd.Basic
 
 namespace DkMath.FLT.Five
 
-/-- An integral pair representing `a + b * phi`, with `phi^2 = phi + 1`. -/
+/-!
+# The quadratic order `ℤ[φ]`
+
+`GoldenInt` is the direct coordinate model `a+b*φ` with `φ^2=φ+1`.  Multiplication,
+conjugation `φ |-> 1-φ`, and norm
+
+`N(a+b*φ) = a^2 + a*b - b^2`
+
+are implemented explicitly.  This is mathematically the familiar golden quadratic
+integer order.  The code does not construct a field-level isomorphism with the ring of
+integers of `ℚ(√5)`; all later arguments use only this coordinate ring and its proved
+ring, norm, divisibility, and Euclidean-domain structure.
+
+The doubled map into `Zsqrtd 5` is used only to certify absence of zero divisors.  The
+elements `sqrtFiveElement = 2φ-1` and `tau = 2+φ` expose the ramification identities
+needed in the FLT5 packet.
+-/
+
+/-- An integral pair representing `a+b*φ` in the basis `1,φ`, with `φ^2=φ+1`. -/
 structure GoldenInt where
   fst : ℤ
   snd : ℤ
@@ -186,12 +204,36 @@ def goldenPhi : GoldenInt := ⟨0, 1⟩
 /-- Embed an integer in the golden order. -/
 def goldenOfInt (a : ℤ) : GoldenInt := ⟨a, 0⟩
 
-/-- The nontrivial conjugation `phi |-> 1 - phi`. -/
+/-- The nontrivial conjugation `a+b*φ |-> (a+b)-b*φ`, induced by `φ |-> 1-φ`. -/
 def goldenConj (x : GoldenInt) : GoldenInt := ⟨x.fst + x.snd, -x.snd⟩
 
-/-- The integral norm of a golden integer. -/
+/-- The integral norm `N(a+b*φ)=a^2+a*b-b^2`. -/
 def goldenNorm (x : GoldenInt) : ℤ :=
   x.fst ^ 2 + x.fst * x.snd - x.snd ^ 2
+
+/-- The defining relation of the coordinate order: `φ^2 = φ+1`. -/
+@[simp] theorem golden_phi_sq :
+    goldenMul goldenPhi goldenPhi = goldenAdd goldenPhi goldenOne := by
+  decide
+
+/-- Conjugation sends `φ` to `1-φ`. -/
+@[simp] theorem goldenConj_phi :
+    goldenConj goldenPhi = goldenSub goldenOne goldenPhi := by
+  decide
+
+/-- The basis unit `φ` has norm `-1`. -/
+@[simp] theorem goldenNorm_phi : goldenNorm goldenPhi = -1 := by
+  norm_num [goldenNorm, goldenPhi]
+
+/-- Conjugation fixes the embedded rational integers. -/
+@[simp] theorem goldenConj_ofInt (a : ℤ) :
+    goldenConj (goldenOfInt a) = goldenOfInt a := by
+  ext <;> simp [goldenConj, goldenOfInt]
+
+/-- The norm of an embedded integer is its square. -/
+@[simp] theorem goldenNorm_ofInt (a : ℤ) :
+    goldenNorm (goldenOfInt a) = a ^ 2 := by
+  simp [goldenNorm, goldenOfInt]
 
 /-- Conjugation is an involution. -/
 theorem goldenConj_invol (x : GoldenInt) :
@@ -207,7 +249,7 @@ theorem goldenConj_mul (x y : GoldenInt) :
 theorem goldenNorm_eq_GoldenNorm (x : GoldenInt) :
     goldenNorm x = GoldenNorm x.fst x.snd := rfl
 
-/-- Compatibility alias using the checkpoint's explicit API name. -/
+/-- Compatibility between the structured norm and the earlier binary quadratic form. -/
 theorem goldenNorm_eq_existing_GoldenNorm (M N : ℤ) :
     goldenNorm (⟨M, N⟩ : GoldenInt) = GoldenNorm M N := rfl
 
@@ -234,10 +276,10 @@ def goldenSqrtFive : GoldenInt := ⟨-1, 2⟩
 /-- The distinguished ramifier `2 + phi`. -/
 def goldenTau : GoldenInt := ⟨2, 1⟩
 
-/-- Checkpoint-facing name for the square root of five. -/
+/-- Short public name for the element `2φ-1`, whose square is five. -/
 abbrev sqrtFiveElement : GoldenInt := goldenSqrtFive
 
-/-- Checkpoint-facing name for the ramified element above five. -/
+/-- Short public name for the distinguished norm-five element `2+φ`. -/
 abbrev tau : GoldenInt := goldenTau
 
 theorem goldenSqrtFive_sq :

--- a/lean/dk_math/DkMath/FLT/Five/GoldenUnitClassification.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GoldenUnitClassification.lean
@@ -6,11 +6,21 @@ Authors: D. and Wise Wolf.
 
 import DkMath.FLT.Five.SignedGoldenUnitClasses
 
+/-!
+# Elementary classification of units in the golden order
+
+Multiplication by `phi` or its integral inverse strictly decreases a coordinate
+measure until a base unit is reached. Reversing that descent expresses every
+unit as a signed power of `phi`, hence as `phi^i * delta^5` for `i : Fin 5`.
+This proves existence of a fifth-power class representative; no uniqueness
+claim is needed downstream.
+-/
+
 #print "file: DkMath.FLT.Five.GoldenUnitClassification"
 
 namespace DkMath.FLT.Five
 
-/-- The integral inverse of `phi`. -/
+/-- The integral inverse `phi - 1` of `phi` in the coordinate model. -/
 def goldenPhiInv : GoldenInt := ⟨-1, 1⟩
 
 theorem golden_phi_mul_inv :
@@ -196,7 +206,7 @@ theorem goldenUnit_descent {x : GoldenInt} (hx : GoldenUnit x)
       rw [mul_assoc, show goldenPhiInv * goldenPhi = 1 by exact golden_inv_mul_phi]
       simp
 
-/-- Membership in one of the five unit sectors modulo fifth powers. -/
+/-- Existence of `i < 5` and `delta` with `x = phi^i * delta^5`. -/
 def GoldenUnitFifthClass (x : GoldenInt) : Prop :=
   ∃ i : Fin 5, ∃ delta : GoldenInt,
     x = goldenMul (goldenPow goldenPhi i.val) (goldenPow delta 5)
@@ -320,7 +330,7 @@ theorem goldenUnitFifthClass_of_unit (x : GoldenInt) (hx : GoldenUnit x) :
         · rw [hrec]
           exact goldenUnitFifthClass_mul_phiInv hyClass
 
-/-- Golden units have exactly five classes modulo fifth powers. -/
+/-- Every golden unit has a representative among five classes modulo fifth powers. -/
 theorem goldenUnitClassesModFifth : GoldenUnitClassesModFifth := by
   intro epsilon hepsilon
   exact goldenUnitFifthClass_of_unit epsilon hepsilon

--- a/lean/dk_math/DkMath/FLT/Five/GoldenUnitClassification.lean
+++ b/lean/dk_math/DkMath/FLT/Five/GoldenUnitClassification.lean
@@ -38,7 +38,8 @@ theorem golden_mul_phi_coords (x : GoldenInt) :
 
 theorem golden_mul_phiInv_coords (x : GoldenInt) :
     goldenMul x goldenPhiInv = ⟨x.snd - x.fst, x.fst⟩ := by
-  ext <;> simp [goldenMul, goldenPhiInv] <;> ring
+  ext <;> simp [goldenMul, goldenPhiInv]
+  all_goals ring
 
 /-- Coordinate size used for the elementary unit descent. -/
 def goldenUnitMeasure (x : GoldenInt) : ℕ :=

--- a/lean/dk_math/DkMath/FLT/Five/Main.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Main.lean
@@ -71,11 +71,20 @@ theorem flt5Target_of_zeroArithmetic
   flt5Target_of_unitClasses_of_zeroArithmetic
     goldenUnitClassesModFifth hArithmetic
 
-/-- The unconditional positive-natural exponent-five endpoint. -/
+/--
+The unconditional exponent-five target for positive natural numbers. It denies
+`Fermat5Equation x y z`, namely `x^5 + y^5 = z^5`, for every positive
+`x`, `y`, and `z`. This is not a general-exponent or signed-integer theorem.
+-/
 theorem flt5Target : FLT5Target :=
   flt5Target_of_zeroArithmetic goldenZeroSectorArithmeticExclusion
 
-/-- Ordinary-argument form: positive `x`, `y`, and `z` cannot solve the equation. -/
+/--
+Ordinary-argument wrapper around `flt5Target`: for positive natural numbers
+`x`, `y`, and `z`, it proves the negation of `Fermat5Equation x y z`, i.e.
+`x^5 + y^5 = z^5`. It does not expose a general-exponent theorem or a theorem
+about arbitrary signed integers.
+-/
 theorem fermatFive_no_positive_solution
     (x y z : ℕ) (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) :
     ¬ Fermat5Equation x y z :=

--- a/lean/dk_math/DkMath/FLT/Five/Main.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Main.lean
@@ -32,11 +32,26 @@ import DkMath.FLT.Five.SquareGoldenBridge
 import DkMath.FLT.Five.SquareGoldenNormalForm
 import DkMath.FLT.Five.Valuation
 
+/-!
+# Fermat's Last Theorem at exponent five
+
+The proof route is: normalize a positive solution to a primitive packet; choose
+one of the two signed gap orientations; split the associated golden-order
+factor into a unit and a fifth power; eliminate four nonzero unit classes; and
+exclude the zero class by a certified strict infinite descent. Conditional
+receiver theorems expose the unit-class and zero-sector boundaries, while
+`flt5Target` and `fermatFive_no_positive_solution` are unconditional endpoints.
+
+The scope is exactly positive natural numbers and exponent five. This module
+does not assert the general Fermat theorem, a novel historical proof, external
+peer review, or acceptance of the development beyond Lean's kernel checks.
+-/
+
 #print "file: DkMath.FLT.Five.Main"
 
 namespace DkMath.FLT.Five
 
-/-- Local exponent-five target, independent of the legacy general-`p ≥ 5` facade. -/
+/-- No positive natural numbers satisfy `x^5 + y^5 = z^5`. -/
 abbrev FLT5Target : Prop :=
   ∀ x y z : ℕ,
     0 < x →
@@ -44,23 +59,23 @@ abbrev FLT5Target : Prop :=
     0 < z →
     ¬ Fermat5Equation x y z
 
-/-- The two exact remaining arithmetic propositions suffice for the final target. -/
+/-- Conditional receiver exposing both unit classification and zero-sector arithmetic. -/
 theorem flt5Target_of_unitClasses_of_zeroArithmetic
     (hClasses : GoldenUnitClassesModFifth)
     (hArithmetic : GoldenZeroSectorArithmeticExclusion) : FLT5Target :=
   positiveFermat5Refuter_of_unitClasses_of_zeroArithmetic hClasses hArithmetic
 
-/-- Unit classification is unconditional, so only the zero-sector arithmetic remains. -/
+/-- Conditional receiver after the proved unit classification is supplied. -/
 theorem flt5Target_of_zeroArithmetic
     (hArithmetic : GoldenZeroSectorArithmeticExclusion) : FLT5Target :=
   flt5Target_of_unitClasses_of_zeroArithmetic
     goldenUnitClassesModFifth hArithmetic
 
-/-- Fermat's equation at exponent five has no positive natural-number solution. -/
+/-- The unconditional positive-natural exponent-five endpoint. -/
 theorem flt5Target : FLT5Target :=
   flt5Target_of_zeroArithmetic goldenZeroSectorArithmeticExclusion
 
-/-- Explicit ordinary-argument form of the closed exponent-five theorem. -/
+/-- Ordinary-argument form: positive `x`, `y`, and `z` cannot solve the equation. -/
 theorem fermatFive_no_positive_solution
     (x y z : ℕ) (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) :
     ¬ Fermat5Equation x y z :=
@@ -83,26 +98,5 @@ theorem positiveFermat5Refuter_of_zeroArithmetic
     PositiveFermat5Refuter :=
   positiveFermat5Refuter_of_unitClasses_of_zeroArithmetic
     goldenUnitClassesModFifth hArithmetic
-
-/-!
-The current reduction tower routes a primitive exponent-five candidate through:
-
-- signed difference/sum Branch-A orientations,
-- an exact common five-adic packet,
-- the power split `carrier = 5^4*a^5`, `residual = 5*b^5`, and
-- a signed square-golden exceptional packet, and
-- an integral golden-order packet with the visible ramifier `tau` stripped.
-- certified relative primality of the stripped element and its conjugate,
-- unconditional fifth-power splitting up to a unit,
-- elimination of unit sectors one through four, and
-- the primitive and exact tenth-power split of the zero sector.
-
-The golden-unit orbit is unconditionally reduced to five classes modulo fifth
-powers.  Certified inversion and factorization expose the exact zero-sector
-arithmetic, and the golden lift supplies a strictly smaller packet of the same
-shape.  Infinite descent therefore proves `goldenZeroSectorArithmeticExclusion`,
-and `flt5Target` closes the exponent-five target while the conditional receivers
-above remain available as reusable interfaces.
--/
 
 end DkMath.FLT.Five

--- a/lean/dk_math/DkMath/FLT/Five/NormalForm.lean
+++ b/lean/dk_math/DkMath/FLT/Five/NormalForm.lean
@@ -10,6 +10,16 @@ import DkMath.FLT.Five.Reduction
 
 namespace DkMath.FLT.Five
 
+/-!
+# Elementary Branch-B fifth-power normal form
+
+This packet records the output of coprime factor separation: both the gap and the
+cyclotomic residual are fifth powers, their bases multiply to the original left-hand
+base, and all positivity and coprimality needed by the square/golden bridge is retained.
+The core declaration is a receiver interface, not an additional assumption of the
+completed public theorem.
+-/
+
 /-- Coprimality passes from the gap to the GN5 residual modulo `y`. -/
 theorem coprime_GN5_y_of_coprime
     {g y : ℕ} (hgy : Nat.Coprime g y) :

--- a/lean/dk_math/DkMath/FLT/Five/Provider.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Provider.lean
@@ -10,6 +10,15 @@ import DkMath.FLT.Five.BranchB
 
 namespace DkMath.FLT.Five
 
+/-!
+# Conditional clean-channel interfaces
+
+These declarations separate the elementary local contradiction from the problem of
+supplying a suitable prime.  They remain useful public interfaces, although the final
+unconditional FLT5 route proceeds through signed five-adic normalization and golden
+descent rather than assuming a global clean-channel provider.
+-/
+
 /-- A Branch-B counterexample receives at least one existential clean GN5 channel. -/
 abbrev BranchBCleanGN5ChannelProvider : Prop :=
   ∀ {x y z : ℕ},
@@ -20,8 +29,8 @@ abbrev BranchBCleanGN5ChannelProvider : Prop :=
 /--
 The unbundled inversion-escape kernel for Branch B.
 
-This is the exact research obligation: one prime enters `GN5`, avoids the gap,
-and fails to lift to its square.
+This is the unbundled form of the local data: one prime enters `GN5`, avoids the gap,
+and fails to lift to its square.  It is retained as a conditional reusable interface.
 -/
 abbrev BranchBNoLiftEscape : Prop :=
   ∀ {x y z : ℕ},

--- a/lean/dk_math/DkMath/FLT/Five/Reduction.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Reduction.lean
@@ -10,6 +10,15 @@ import DkMath.FLT.Five.GN5
 
 namespace DkMath.FLT.Five
 
+/-!
+# Primitive factor separation away from five
+
+For a primitive candidate the gap `g=z-y` is coprime to `y`.  The congruence
+`GN5(g,y) ≡ 5*y^4 (mod g)` then shows that any common prime of `g` and `GN5(g,y)`
+is five.  In Branch B, where `5` does not divide the gap, the two factors are coprime
+and their fifth-power product splits into two fifth powers.
+-/
+
 /-- A counterexample pack forces the second and result coordinates to be coprime. -/
 theorem coprime_y_z_of_counterexamplePack
     {x y z : ℕ} (hPack : CounterexamplePack x y z) :
@@ -48,8 +57,7 @@ theorem dvd_five_mul_y_pow_four_of_dvd_gap_of_dvd_GN5
       GN5 g y =
         g * (g ^ 3 + 5 * g ^ 2 * y + 10 * g * y ^ 2 + 10 * y ^ 3) +
           5 * y ^ 4 := by
-    unfold GN5
-    ring
+    exact GN5_eq_gap_mul_add_five_mul_y_pow_four g y
   have hqPrefix :
       q ∣ g * (g ^ 3 + 5 * g ^ 2 * y + 10 * g * y ^ 2 + 10 * y ^ 3) :=
     dvd_mul_of_dvd_left hqg _

--- a/lean/dk_math/DkMath/FLT/Five/SignedBranchA.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedBranchA.lean
@@ -11,6 +11,15 @@ import DkMath.FLT.Five.BranchB
 
 namespace DkMath.FLT.Five
 
+/-!
+# Signed routing into the exceptional five-adic branch
+
+A primitive candidate with `5` absent from one natural gap is routed, after possibly
+swapping the left inputs, to exactly one of two useful orientations: a five-divisible
+difference gap or a five-divisible sum.  A kernel-checked mod-25 classification supplies
+the divisibility needed by the common packet constructed in `SignedFiveAdic.lean`.
+-/
+
 /-- Swapping the two left coordinates preserves a counterexample pack. -/
 theorem CounterexamplePack.swap
     {x y z : ℕ} (hPack : CounterexamplePack x y z) :
@@ -27,12 +36,7 @@ theorem five_not_dvd_GN5_of_five_not_dvd_gap
     {g y : ℕ} (h5g : ¬ 5 ∣ g) :
     ¬ 5 ∣ GN5 g y := by
   intro h5GN
-  have hdecomp :
-      GN5 g y =
-        g ^ 4 +
-          5 * (g ^ 3 * y + 2 * g ^ 2 * y ^ 2 + 2 * g * y ^ 3 + y ^ 4) := by
-    unfold GN5
-    ring
+  have hdecomp := GN5_eq_g_pow_four_add_five_mul g y
   have h5tail :
       5 ∣ 5 * (g ^ 3 * y + 2 * g ^ 2 * y ^ 2 + 2 * g * y ^ 3 + y ^ 4) :=
     dvd_mul_of_dvd_left (dvd_refl 5) _

--- a/lean/dk_math/DkMath/FLT/Five/SignedFiveAdic.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedFiveAdic.lean
@@ -10,7 +10,19 @@ import DkMath.FLT.Five.SignedBranchA
 
 namespace DkMath.FLT.Five
 
-/-- The positive fifth-power residual for the sum factorization. -/
+/-!
+# Common exact five-adic packet
+
+The difference and sum orientations are representationally different but have the same
+arithmetic output.  Their carrier times residual is a fifth power, the residual is
+`5 mod 25` and therefore has `v_5 = 1`, while the carrier valuation is `4 mod 5`.
+`SumGN5` is the positive natural quotient `(u^5+v^5)/(u+v)`; its piecewise definition
+only avoids signed subtraction in `Nat` and is not a mathematical asymmetry.
+-/
+
+/-- The positive natural residual in `(u+v) * SumGN5(u,v) = u^5+v^5`.
+The two branches choose the nonnegative difference used to write the same symmetric
+homogeneous quotient without leaving `ℕ`. -/
 def SumGN5 (u v : ℕ) : ℕ :=
   if v ≤ u then
     (u - v) ^ 4 +
@@ -266,7 +278,9 @@ inductive SignedFiveAdicSource
       distinguished = w →
       SignedFiveAdicSource u v w carrier residual distinguished
 
-/-- Common five-adic packet obtained from either signed Branch-A orientation. -/
+/-- The common exact five-adic invariant produced by either signed orientation.
+Besides the factor equation it records `residual ≡ 5 (mod 25)`, `v_5(residual)=1`,
+and `v_5(carrier) ≡ 4 (mod 5)` so later layers never reopen the residue proof. -/
 structure SignedFiveAdicPacket (u v w : ℕ) : Type where
   normal : SignedBranchANormalForm u v w
   carrier : ℕ
@@ -382,7 +396,7 @@ noncomputable def signedFiveAdicPacket_of_normalForm
     SignedFiveAdicPacket u v w :=
   Classical.choice (nonempty_signedFiveAdicPacket_of_normalForm hNF)
 
-/-- The remaining common arithmetic kernel after exact signed five-adic reduction. -/
+/-- Receiver contract for contradictions formulated on the common five-adic packet. -/
 abbrev SignedFiveAdicCore : Prop :=
   ∀ {u v w : ℕ}, SignedFiveAdicPacket u v w → False
 

--- a/lean/dk_math/DkMath/FLT/Five/SignedFiveAdicPowerSplit.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedFiveAdicPowerSplit.lean
@@ -11,6 +11,18 @@ import DkMath.FLT.Five.Reduction
 
 namespace DkMath.FLT.Five
 
+/-!
+# Removing the exact five-adic load
+
+The carrier and residual have gcd exactly five.  Removing it and splitting the remaining
+coprime fifth-power product yields
+
+`carrier = 5^4*a^5`, `residual = 5*b^5`, `distinguished = 5*a*b`,
+
+with positive coprime `a,b` and `5` absent from `b`.  These retained coprimality facts
+are the input for stripping the ramified element in the quadratic order.
+-/
+
 private theorem dvd_five_mul_left_pow_four_of_dvd_sum_of_dvd_sumGN5
     {u v q : ℕ} (hqsum : q ∣ u + v) (hqres : q ∣ SumGN5 u v) :
     q ∣ 5 * u ^ 4 := by
@@ -69,7 +81,7 @@ theorem signedFiveAdicPacket_gcd_eq_five
       omega
     exact Nat.dvd_gcd p.five_dvd_carrier h5res
 
-/-- Exact fifth-power split of the signed five-adic packet. -/
+/-- Exact fifth-power split after assigning the unique common factor five. -/
 structure SignedFiveAdicPowerSplit
     (u v w : ℕ) : Type where
   fiveAdic : SignedFiveAdicPacket u v w
@@ -217,7 +229,7 @@ noncomputable def signedFiveAdicPowerSplit_of_normalForm
     SignedFiveAdicPowerSplit u v w :=
   signedFiveAdicPowerSplit_of_packet (signedFiveAdicPacket_of_normalForm hNF)
 
-/-- Remaining arithmetic kernel after the exact power split. -/
+/-- Receiver contract for contradictions stated on the exact power-split packet. -/
 abbrev SignedFiveAdicPowerSplitCore : Prop :=
   ∀ {u v w : ℕ}, SignedFiveAdicPowerSplit u v w → False
 

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenClosure.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenClosure.lean
@@ -6,13 +6,24 @@ Authors: D. and Wise Wolf.
 
 import DkMath.FLT.Five.SignedGoldenZeroSector
 
+/-!
+# Receiver interfaces from zero-sector arithmetic to FLT5
+
+This module packages the forward implication chain without assuming its final
+arithmetic input: a zero-sector exclusion eliminates unit-times-fifth-power
+packets; the two gap orientations eliminate primitive counterexamples; and gcd
+normalization reduces every positive solution to such a packet. The conditional
+receivers remain public even though the imported final layer later proves their
+input, making each boundary independently reusable and auditable.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenClosure"
 
 namespace DkMath.FLT.Five
 
 /--
-The exact remaining zero-sector Diophantine proposition after the certified
-primitive and tenth-power splits.
+The zero-sector Diophantine proposition exposed by the certified primitive and
+tenth-power splits.
 -/
 abbrev GoldenZeroSectorArithmeticExclusion : Prop :=
   ∀ (r s : ℤ) (a b : ℕ),
@@ -85,7 +96,7 @@ theorem counterexamplePackRefuter_of_unitFifthPowerExclusion
   · exact branchB_false_of_unitFifthPowerExclusion hExclude p hyGap
   · exact branchB_false_of_unitFifthPowerExclusion hExclude p.swap hxGap
 
-/-- The two exact remaining arithmetic inputs suffice for all primitive packets. -/
+/-- Unit classification and zero-sector arithmetic suffice for all primitive packets. -/
 theorem counterexamplePackRefuter_of_unitClasses_of_zeroArithmetic
     (hClasses : GoldenUnitClassesModFifth)
     (hArithmetic : GoldenZeroSectorArithmeticExclusion) :
@@ -146,7 +157,7 @@ theorem positiveFermat5Refuter_of_counterexamplePackRefuter
     ⟨x', y', z', p⟩
   exact hPrimitive p
 
-/-- The two exact arithmetic inputs suffice for the full positive target. -/
+/-- Unit classification and zero-sector arithmetic suffice for the full positive target. -/
 theorem positiveFermat5Refuter_of_unitClasses_of_zeroArithmetic
     (hClasses : GoldenUnitClassesModFifth)
     (hArithmetic : GoldenZeroSectorArithmeticExclusion) :

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenConjugateCoprime.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenConjugateCoprime.lean
@@ -10,6 +10,16 @@ import DkMath.FLT.Five.SignedGoldenRamifierStripped
 
 namespace DkMath.FLT.Five
 
+/-!
+# Relative primality of a stripped element and its conjugate
+
+A common divisor of `beta` and `conj(beta)` divides both `N(beta)=b^5` and the norm of
+their difference, `-5^15*a^20`.  The power-split coprimality says these integer masses
+are coprime, so the common divisor has norm `±1` and is a golden unit.  The resulting
+`GoldenRelPrime` certificate is precisely the hypothesis needed for fifth-power
+factor extraction in the Euclidean domain.
+-/
+
 /-- Subtracting the conjugate isolates the square-root-of-five direction. -/
 theorem golden_sub_conj_eq_snd_mul_sqrtFive (x : GoldenInt) :
     x - goldenConj x = goldenMul (goldenOfInt x.snd) sqrtFiveElement := by
@@ -82,7 +92,8 @@ noncomputable def signedGoldenConjugateCoprimePacket_of_normalForm
   signedGoldenConjugateCoprimePacket_of_stripped
     (signedGoldenRamifierStrippedPacket_of_normalForm hNF)
 
-/-- Remaining core after conjugate coprimality is certified. -/
+/-- Receiver contract for contradictions on packets carrying certified conjugate
+relative primality. -/
 abbrev SignedGoldenConjugateCoprimeCore : Prop :=
   ∀ {u v w : ℕ}, SignedGoldenConjugateCoprimePacket u v w → False
 

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenFifthPower.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenFifthPower.lean
@@ -10,6 +10,15 @@ import DkMath.FLT.Five.SignedGoldenConjugateCoprime
 
 namespace DkMath.FLT.Five
 
+/-!
+# Fifth-power extraction up to a unit
+
+The norm identity writes a stripped element and its conjugate as two relatively prime
+factors of an embedded fifth power.  This module states the exact generic algebraic
+contract needed to extract one factor as `epsilon*gamma^5`; the contract is proved from
+the norm-Euclidean domain in `GoldenCoprimeFactor.lean`.
+-/
+
 /-- Integer embedding respects fifth powers in the explicit golden API. -/
 theorem goldenOfInt_pow_five (b : ℤ) :
     goldenOfInt (b ^ 5) = goldenPow (goldenOfInt b) 5 := by
@@ -26,9 +35,8 @@ theorem SignedGoldenRamifierStrippedPacket.beta_mul_conj_eq_fifth
   rw [golden_mul_conj, p.beta_norm, goldenOfInt_pow_five]
 
 /--
-The narrow factorization theorem missing from the current library: a factor of
-a fifth power that is relatively prime to its complementary factor is itself a
-fifth power up to a unit.
+The generic factorization contract: a factor of a fifth power that is relatively prime
+to its complementary factor is itself a fifth power up to a unit.
 -/
 abbrev GoldenCoprimeFactorOfFifthPower : Prop :=
   ∀ x y z : GoldenInt,
@@ -38,7 +46,8 @@ abbrev GoldenCoprimeFactorOfFifthPower : Prop :=
       GoldenUnit epsilon ∧
       x = goldenMul epsilon (goldenPow gamma 5)
 
-/-- The generic missing factorization theorem exactly inhabits the cp-004e core. -/
+/-- Any implementation of the generic coprime-factor theorem supplies the stripped
+packet's unit-times-fifth-power representation. -/
 theorem signedGoldenFifthPowerUpToUnitCore_of_coprimeFactor
     (hFactor : GoldenCoprimeFactorOfFifthPower) :
     SignedGoldenFifthPowerUpToUnitCore := by

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenRamifierStripped.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenRamifierStripped.lean
@@ -11,6 +11,19 @@ import DkMath.FLT.Five.SignedSquareGoldenExceptional
 
 namespace DkMath.FLT.Five
 
+/-!
+# Removing the ramified factor above five
+
+The square/norm packet gives `alpha` with norm `5*b^5`.  Divisibility of the diagonal
+coordinate extracts the explicit norm-five element `tau=2+φ`, writing
+`alpha=tau*beta`.  The stripped element satisfies
+
+`N(beta)=b^5`, `beta.snd=-5^7*a^10`, `5 ∤ N(beta)`,
+
+and is not divisible by `tau` again.  These facts isolate the unique visible ramified
+load before comparing `beta` with its conjugate.
+-/
+
 /-- The exceptional packet after removing the unique visible ramifier `tau`. -/
 structure SignedGoldenRamifierStrippedPacket (u v w : ℕ) : Type where
   exceptional : SignedSquareGoldenExceptionalPacket u v w
@@ -128,7 +141,7 @@ noncomputable def signedGoldenRamifierStrippedPacket_of_normalForm
   signedGoldenRamifierStrippedPacket_of_powerSplit
     (signedFiveAdicPowerSplit_of_normalForm hNF)
 
-/-- Remaining kernel after the visible golden ramifier has been removed. -/
+/-- Receiver contract for contradictions stated after the visible ramifier is removed. -/
 abbrev SignedGoldenRamifierStrippedCore : Prop :=
   ∀ {u v w : ℕ}, SignedGoldenRamifierStrippedPacket u v w → False
 
@@ -147,9 +160,9 @@ theorem branchB_false_of_goldenRamifierStrippedCore
     (signedBranchARefuter_of_goldenRamifierStrippedCore hCore) hPack hBranch
 
 /--
-The exact next algebraic contract: every stripped exceptional element is a
-fifth power up to a golden unit.  Establishing this requires the missing
-factorization/coprimality and unit-classification layer; it is not assumed here.
+The algebraic output requested from a stripped packet: `beta` is a fifth power up to a
+golden unit.  `GoldenCoprimeFactor.signedGoldenFifthPowerUpToUnitCore` proves this
+contract unconditionally after conjugate relative primality is certified.
 -/
 abbrev SignedGoldenFifthPowerUpToUnitCore : Prop :=
   ∀ {u v w : ℕ} (p : SignedGoldenRamifierStrippedPacket u v w),

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenSectorArithmetic.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenSectorArithmetic.lean
@@ -96,11 +96,13 @@ theorem five_dvd_goldenNorm_of_five_dvd_fifthFst
     (5 : ℤ) ∣ goldenNorm gamma := by
   have hdiff := five_dvd_goldenFifthFstPoly_sub_linear gamma.fst gamma.snd
   have hlinear : (5 : ℤ) ∣ gamma.fst + 3 * gamma.snd := by
-    convert dvd_sub hF hdiff using 1 <;> ring
+    convert dvd_sub hF hdiff using 1
+    all_goals ring
   have hsq : (5 : ℤ) ∣ (gamma.fst + 3 * gamma.snd) ^ 2 :=
     dvd_pow hlinear (by decide)
   have hnormDiff := five_dvd_goldenNorm_sub_linear_sq gamma
-  convert dvd_add hnormDiff hsq using 1 <;> ring
+  convert dvd_add hnormDiff hsq using 1
+  all_goals ring
 
 private theorem five_dvd_beta_snd
     {u v w : ℕ} (p : SignedGoldenRamifierStrippedPacket u v w) :
@@ -124,18 +126,24 @@ theorem signedGolden_nonzero_unitSector_false
   fin_cases i
   · exact (hi rfl).elim
   · rw [hbeta, golden_unit_one_mul_fifth_snd] at hb
-    convert dvd_sub hb hS using 1 <;> ring
+    convert dvd_sub hb hS using 1
+    all_goals ring
   · rw [hbeta, golden_unit_two_mul_fifth_snd] at hb
-    convert dvd_sub hb (dvd_mul_of_dvd_right hS 2) using 1 <;> ring
+    convert dvd_sub hb (dvd_mul_of_dvd_right hS 2) using 1
+    all_goals ring
   · rw [hbeta, golden_unit_three_mul_fifth_snd] at hb
     have h2F : (5 : ℤ) ∣ 2 * goldenFifthFstPoly gamma.fst gamma.snd :=
-      by convert dvd_sub hb (dvd_mul_of_dvd_right hS 3) using 1 <;> ring
+      by
+        convert dvd_sub hb (dvd_mul_of_dvd_right hS 3) using 1
+        all_goals ring
     rcases (show Prime (5 : ℤ) by norm_num).dvd_mul.mp h2F with h52 | hF
     · norm_num at h52
     · exact hF
   · rw [hbeta, golden_unit_four_mul_fifth_snd] at hb
     have h3F : (5 : ℤ) ∣ 3 * goldenFifthFstPoly gamma.fst gamma.snd :=
-      by convert dvd_sub hb (dvd_mul_of_dvd_right hS 5) using 1 <;> ring
+      by
+        convert dvd_sub hb (dvd_mul_of_dvd_right hS 5) using 1
+        all_goals ring
     rcases (show Prime (5 : ℤ) by norm_num).dvd_mul.mp h3F with h53 | hF
     · norm_num at h53
     · exact hF

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenSectorArithmetic.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenSectorArithmetic.lean
@@ -6,11 +6,20 @@ Authors: D. and Wise Wolf.
 
 import DkMath.FLT.Five.SignedGoldenUnitClasses
 
+/-!
+# Arithmetic elimination of the nonzero unit sectors
+
+The second-coordinate formula for `phi^i * gamma^5`, reduced modulo five,
+shows that each sector `i = 1, 2, 3, 4` forces `5 ∣ goldenNorm gamma`. This
+contradicts the packet invariant `5 ∤ b`, because that norm is `b` up to sign.
+Only sector zero, where `beta = gamma^5`, survives for the separate descent.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenSectorArithmetic"
 
 namespace DkMath.FLT.Five
 
-/-- The quartic factor in the second coordinate of a golden fifth power. -/
+/-- The quartic `H(r,s)` in `(r + s*phi)^5.snd = 5*s*H(r,s)`. -/
 def goldenFifthSndFactor (r s : ℤ) : ℤ :=
   r ^ 4 + 2 * r ^ 3 * s + 4 * r ^ 2 * s ^ 2 +
     3 * r * s ^ 3 + s ^ 4
@@ -131,7 +140,7 @@ theorem signedGolden_nonzero_unitSector_false
     · norm_num at h53
     · exact hF
 
-/-- The exact arithmetic contract remaining after all nonzero sectors are removed. -/
+/-- The zero-sector contract left after sectors one through four are eliminated. -/
 abbrev SignedGoldenZeroSectorExclusion : Prop :=
   ∀ {u v w : ℕ} (p : SignedGoldenRamifierStrippedPacket u v w)
     (gamma : GoldenInt),

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenUnitClasses.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenUnitClasses.lean
@@ -7,6 +7,16 @@ Authors: D. and Wise Wolf.
 import DkMath.FLT.Five.GoldenCoprimeFactor
 import DkMath.FLT.Five.GoldenFifthPowerCoordinates
 
+/-!
+# Unit classes and the five algebraic sectors
+
+The coprime-factor theorem writes the stripped golden factor as
+`beta = epsilon * gamma^5`, where `epsilon` is a unit. Classification modulo
+fifth powers reduces `epsilon` to one of `1, phi, ..., phi^4`; a sign is absorbed
+into `gamma` because the exponent is odd. These are algebraic unit classes,
+not geometric angular sectors.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenUnitClasses"
 
 namespace DkMath.FLT.Five
@@ -53,8 +63,8 @@ theorem SignedGoldenRamifierStrippedPacket.unitSector_snd_eq
   rw [← hbeta, p.beta_snd]
 
 /--
-The exact remaining packet arithmetic proposition after unconditional factor
-splitting: no packet's `beta` is a unit times a fifth power.
+The reusable packet exclusion produced by the sector arithmetic: no packet's
+`beta` can be a unit times a fifth power.
 -/
 abbrev SignedGoldenUnitFifthPowerExclusion : Prop :=
   ∀ {u v w : ℕ} (p : SignedGoldenRamifierStrippedPacket u v w)
@@ -63,7 +73,7 @@ abbrev SignedGoldenUnitFifthPowerExclusion : Prop :=
     p.beta = goldenMul epsilon (goldenPow gamma 5) →
     False
 
-/-- The remaining unit/coordinate exclusion is sufficient for the stripped core. -/
+/-- The unit/coordinate exclusion is sufficient for the stripped core. -/
 theorem signedGoldenRamifierStrippedCore_of_unitFifthPowerExclusion
     (hExclude : SignedGoldenUnitFifthPowerExclusion) :
     SignedGoldenRamifierStrippedCore := by

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSector.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSector.lean
@@ -67,7 +67,8 @@ theorem SignedGoldenRamifierStrippedPacket.zeroSector_five_not_dvd_sndFactor
   apply p.zeroSector_five_not_dvd_gamma_norm hbeta
   have hdiff := five_dvd_goldenFifthSndFactor_sub_norm_sq gamma
   have hnormSq : (5 : ℤ) ∣ goldenNorm gamma ^ 2 := by
-    convert dvd_sub hH hdiff using 1 <;> ring
+    convert dvd_sub hH hdiff using 1
+    all_goals ring
   exact (show Prime (5 : ℤ) by norm_num).dvd_of_dvd_pow hnormSq
 
 /-- Natural absolute-value form of the zero-sector product equation. -/
@@ -136,7 +137,8 @@ theorem SignedGoldenRamifierStrippedPacket.zeroSector_coprime_s_sndFactor
       simp only [goldenFifthSndFactor]
       rw [hk]
       ring
-    convert dvd_sub hqHZ htail using 1 <;> ring
+    convert dvd_sub hqHZ htail using 1
+    all_goals ring
   have hqr4 : q ∣ gamma.fst.natAbs ^ 4 := by
     simpa [Int.natAbs_pow] using Int.natCast_dvd.mp hqR4
   have hqr : q ∣ gamma.fst.natAbs := hqPrime.dvd_of_dvd_pow hqr4

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSector.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSector.lean
@@ -6,6 +6,16 @@ Authors: D. and Wise Wolf.
 
 import DkMath.FLT.Five.SignedGoldenSectorArithmetic
 
+/-!
+# Primitive arithmetic in the zero unit sector
+
+For `gamma = (r,s)` with `beta = gamma^5`, the packet supplies
+`s * H(r,s) = -5^6 * a^10`, `goldenNorm gamma = ±b`, `gcd(a,b)=1`, and
+`5 ∤ b`. Coordinate primitivity makes `s` coprime to `H(r,s)`. The product
+therefore splits as `|s| = 5^6*c^10` and `|H(r,s)| = d^10`, which is the exact
+input to the inversion and descent layers.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenZeroSector"
 
 namespace DkMath.FLT.Five

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
@@ -26,7 +26,7 @@ closure is acyclic rather than circular.
 namespace DkMath.FLT.Five
 
 /--
-The quadratic re-entry map used in the classical exponent-five descent.  Its
+The quadratic re-entry map used in the golden-order exponent-five descent.  Its
 norm is the quartic occurring in the second coordinate of a golden fifth
 power, while its second coordinate is a square.
 -/

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
@@ -7,6 +7,20 @@ Authors: D. and Wise Wolf.
 import DkMath.FLT.Five.SignedGoldenZeroSectorInversion
 import DkMath.FLT.Five.GoldenUnitClassification
 
+/-!
+# Infinite descent for the zero sector
+
+The lift `T(r,s) = (r^2+r*s+s^2, s^2)` has norm `H(r,s)`. A descent packet
+records `|s| = 5*t^5`, `H(r,s) = D^5`, primitive coordinates, and norm prime to
+five. Relative-prime factorization makes the lift a unit times a fifth power;
+the nonzero unit sectors are impossible, so it is an honest fifth power.
+Coprime splitting then constructs a new packet whose second-coordinate
+absolute value is strictly smaller. Strong induction closes the descent.
+
+The proof does not invoke the final FLT5 theorem or its receivers, so the
+closure is acyclic rather than circular.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenZeroSectorDescent"
 
 namespace DkMath.FLT.Five
@@ -52,6 +66,7 @@ structure GoldenZeroSectorDescentPacket where
     goldenFifthSndFactor base.fst base.snd = (D : ℤ) ^ 5
   five_not_dvd_norm : ¬ (5 : ℤ) ∣ goldenNorm base
 
+/-- The positive natural measure decreased by every certified descent step. -/
 def goldenZeroSectorDescentMeasure (p : GoldenZeroSectorDescentPacket) : ℕ :=
   p.base.snd.natAbs
 
@@ -496,7 +511,7 @@ theorem GoldenZeroSectorDescentPacket.strictDescent
     lift_eq := hroot
     measure_lt := p.fifthRoot_measure_lt gamma hroot }⟩
 
-/-- Infinite descent excludes every packet carrying the recursive fifth-power shape. -/
+/-- Strong induction excludes every packet carrying the recursive fifth-power shape. -/
 theorem goldenZeroSectorDescentPacket_false
     (p : GoldenZeroSectorDescentPacket) : False := by
   have noAt : ∀ n : ℕ, ∀ q : GoldenZeroSectorDescentPacket,
@@ -510,7 +525,7 @@ theorem goldenZeroSectorDescentPacket_false
           (by simpa [hq] using step.measure_lt) step.next rfl
   exact noAt (goldenZeroSectorDescentMeasure p) p rfl
 
-/-- Every certified arithmetic candidate enters the recursive descent invariant. -/
+/-- Every certified zero-sector candidate enters the recursive descent invariant. -/
 def goldenZeroSectorDescentPacket_of_candidate
     (p : GoldenZeroSectorCandidate) : GoldenZeroSectorDescentPacket where
   base := ⟨p.r, p.s⟩

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
@@ -36,6 +36,11 @@ def goldenZeroSectorLift (x : GoldenInt) : GoldenInt :=
 theorem goldenZeroSectorLift_snd (x : GoldenInt) :
     (goldenZeroSectorLift x).snd = x.snd ^ 2 := rfl
 
+/--
+The quadratic lift turns the quartic `H(r,s)` into a golden norm. This identity
+is the algebraic re-entry point: when `H(r,s)` is a fifth power, relative-prime
+factorization can express the lift as a unit times a golden fifth power.
+-/
 theorem goldenZeroSectorLift_norm (x : GoldenInt) :
     goldenNorm (goldenZeroSectorLift x) =
       goldenFifthSndFactor x.fst x.snd := by
@@ -342,6 +347,11 @@ theorem fifthRoot_five_not_dvd_H
   rw [hnorm] at hnormFive
   exact p.five_not_dvd_D (by exact_mod_cast hnormFive)
 
+/--
+The fifth root has strictly smaller visible coordinate: its second-coordinate
+absolute value is less than the source packet's `|s|`. This is the essential
+well-founded inequality used when the root becomes the base of the next packet.
+-/
 theorem fifthRoot_measure_lt
     (p : GoldenZeroSectorDescentPacket) (gamma : GoldenInt)
     (hroot : goldenZeroSectorLift p.base = goldenPow gamma 5) :
@@ -485,6 +495,12 @@ structure GoldenZeroSectorStrictDescent
     goldenZeroSectorDescentMeasure next <
       goldenZeroSectorDescentMeasure source
 
+/--
+Construct the next descent packet from a fifth root of the quadratic lift. The
+new visible coordinate is the root's second coordinate; coprimality, the
+fifth-power shape, and the norm condition are preserved, while
+`fifthRoot_measure_lt` proves that its `|s|` measure strictly decreases.
+-/
 theorem GoldenZeroSectorDescentPacket.strictDescent
     (p : GoldenZeroSectorDescentPacket) :
     Nonempty (GoldenZeroSectorStrictDescent p) := by
@@ -511,7 +527,13 @@ theorem GoldenZeroSectorDescentPacket.strictDescent
     lift_eq := hroot
     measure_lt := p.fifthRoot_measure_lt gamma hroot }⟩
 
-/-- Strong induction excludes every packet carrying the recursive fifth-power shape. -/
+/--
+Strong induction on the visible measure `|s|` excludes every recursive descent
+packet. `strictDescent` preserves the packet invariant and supplies a smaller
+natural measure, so `Nat.strong_induction_on` applies. The argument uses only
+the golden lift and preceding packet lemmas, never the final FLT5 theorem; hence
+the closure is non-circular.
+-/
 theorem goldenZeroSectorDescentPacket_false
     (p : GoldenZeroSectorDescentPacket) : False := by
   have noAt : ∀ n : ℕ, ∀ q : GoldenZeroSectorDescentPacket,

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
@@ -103,7 +103,8 @@ theorem five_not_dvd_H (p : GoldenZeroSectorDescentPacket) :
   apply p.five_not_dvd_norm
   have hdiff := five_dvd_goldenFifthSndFactor_sub_norm_sq p.base
   have hnormSq : (5 : ℤ) ∣ goldenNorm p.base ^ 2 := by
-    convert dvd_sub hH hdiff using 1 <;> ring
+    convert dvd_sub hH hdiff using 1
+    all_goals ring
   exact (show Prime (5 : ℤ) by norm_num).dvd_of_dvd_pow hnormSq
 
 theorem five_not_dvd_D (p : GoldenZeroSectorDescentPacket) :
@@ -193,20 +194,24 @@ theorem five_dvd_norm_of_nonzero_goldenUnitSector
   fin_cases i
   · exact (hi rfl).elim
   · rw [hAlpha, golden_unit_one_mul_fifth_snd] at hFive
-    convert dvd_sub hFive hS using 1 <;> ring
+    convert dvd_sub hFive hS using 1
+    all_goals ring
   · rw [hAlpha, golden_unit_two_mul_fifth_snd] at hFive
-    convert dvd_sub hFive (dvd_mul_of_dvd_right hS 2) using 1 <;> ring
+    convert dvd_sub hFive (dvd_mul_of_dvd_right hS 2) using 1
+    all_goals ring
   · rw [hAlpha, golden_unit_three_mul_fifth_snd] at hFive
     have h2F : (5 : ℤ) ∣
         2 * goldenFifthFstPoly gamma.fst gamma.snd := by
-      convert dvd_sub hFive (dvd_mul_of_dvd_right hS 3) using 1 <;> ring
+      convert dvd_sub hFive (dvd_mul_of_dvd_right hS 3) using 1
+      all_goals ring
     rcases (show Prime (5 : ℤ) by norm_num).dvd_mul.mp h2F with h52 | hF
     · norm_num at h52
     · exact hF
   · rw [hAlpha, golden_unit_four_mul_fifth_snd] at hFive
     have h3F : (5 : ℤ) ∣
         3 * goldenFifthFstPoly gamma.fst gamma.snd := by
-      convert dvd_sub hFive (dvd_mul_of_dvd_right hS 5) using 1 <;> ring
+      convert dvd_sub hFive (dvd_mul_of_dvd_right hS 5) using 1
+      all_goals ring
     rcases (show Prime (5 : ℤ) by norm_num).dvd_mul.mp h3F with h53 | hF
     · norm_num at h53
     · exact hF
@@ -341,7 +346,8 @@ theorem fifthRoot_five_not_dvd_H
   intro hH
   have hdiff := five_dvd_goldenFifthSndFactor_sub_norm_sq gamma
   have hnormSq : (5 : ℤ) ∣ goldenNorm gamma ^ 2 := by
-    convert dvd_sub hH hdiff using 1 <;> ring
+    convert dvd_sub hH hdiff using 1
+    all_goals ring
   have hnormFive : (5 : ℤ) ∣ goldenNorm gamma :=
     (show Prime (5 : ℤ) by norm_num).dvd_of_dvd_pow hnormSq
   rw [hnorm] at hnormFive

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorFactorization.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorFactorization.lean
@@ -6,6 +6,17 @@ Authors: D. and Wise Wolf.
 
 import DkMath.FLT.Five.SignedGoldenZeroSectorInversion
 
+/-!
+# Exact factor packets after zero-sector inversion
+
+The positive factors `A0` and `B0` are split according to their two-adic
+content. The odd branch gives the `(2,2)` allocation; the even branches give
+`(8,16)` or `(16,8)`. Each packet retains its source candidate, exact product,
+exact difference, coprimality after removing powers of two, and fifth-power
+factor data. The odd branch also exposes a modulo-eleven channel, but that
+channel is recorded as structure rather than asserted to be a contradiction.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenZeroSectorFactorization"
 
 namespace DkMath.FLT.Five
@@ -550,8 +561,7 @@ theorem nonempty_goldenZeroSectorFactorPacket
   ⟨goldenZeroSectorFactorPacket_of_inversion
     (goldenZeroSectorInversionPacket p)⟩
 
-/-- The explicit next arithmetic frontier after certified inversion and
-factorization. -/
+/-- Exclusion of every certified exact factor branch. -/
 abbrev GoldenZeroSectorFactorExclusion : Prop :=
   GoldenZeroSectorFactorPacket → False
 

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorFactorization.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorFactorization.lean
@@ -363,7 +363,7 @@ theorem GoldenZeroSectorInversionPacket.eight_dvd_factors
     rw [hrh, hst]
     ring
   have hEvenSub : Even (u - w) := by
-    simpa [Int.even_sub', huOdd, hwOdd]
+    simp [Int.even_sub', huOdd, hwOdd]
   have hEvenAdd : Even (u + w) := huOdd.add_odd hwOdd
   have h8AZ : (8 : ℤ) ∣ zeroSectorA p.source.r p.source.s p.source.d := by
     rcases even_iff_two_dvd.mp hEvenSub with ⟨t, ht⟩
@@ -427,7 +427,8 @@ private theorem nonempty_even_factorData
       · rw [hA8]
         exact dvd_mul_of_dvd_right hqA1 8
       · rw [hB8, hB2]
-        convert dvd_mul_of_dvd_right hqB2 16 using 1 <;> ring
+        convert dvd_mul_of_dvd_right hqB2 16 using 1
+        all_goals ring
     have hred : A1 * B2 = Q2 ^ 5 := by
       apply Nat.mul_left_cancel (show 0 < 128 by norm_num)
       calc
@@ -486,7 +487,8 @@ private theorem nonempty_even_factorData
         intro q hq hq2 hqB1 hqA2
         apply p.no_common_odd_prime q hq hq2
         · rw [hA8, hA2]
-          convert dvd_mul_of_dvd_right hqA2 16 using 1 <;> ring
+          convert dvd_mul_of_dvd_right hqA2 16 using 1
+          all_goals ring
         · rw [hB8]
           exact dvd_mul_of_dvd_right hqB1 8
       exact hcop'.symm

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorFinal.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorFinal.lean
@@ -8,6 +8,15 @@ import DkMath.FLT.Five.SignedGoldenZeroSectorFactorization
 import DkMath.FLT.Five.SignedGoldenZeroSectorDescent
 import DkMath.FLT.Five.SignedGoldenClosure
 
+/-!
+# Closing the zero-sector receiver
+
+Every exact factor packet retains its inversion source. That source produces a
+descent packet, and strict infinite descent proves it impossible. The resulting
+factor exclusion is converted back to the source-level arithmetic contract
+used by `SignedGoldenClosure`.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenZeroSectorFinal"
 
 namespace DkMath.FLT.Five
@@ -23,7 +32,7 @@ theorem goldenZeroSectorArithmeticExclusion_of_factorExclusion
     GoldenZeroSectorArithmeticExclusion :=
   goldenZeroSectorFactorArithmeticExclusion_of_factorExclusion hFactor
 
-/-- Infinite descent discharges the exact arithmetic receiver left by closure. -/
+/-- Infinite descent proves the public zero-sector arithmetic exclusion. -/
 theorem goldenZeroSectorArithmeticExclusion :
     GoldenZeroSectorArithmeticExclusion :=
   goldenZeroSectorArithmeticExclusion_of_factorExclusion

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorInversion.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorInversion.lean
@@ -135,7 +135,8 @@ theorem coprime_natAbs_goldenFifthSndFactor_of_coprime
       simp only [goldenFifthSndFactor]
       rw [hk]
       ring
-    convert dvd_sub hqHZ htail using 1 <;> ring
+    convert dvd_sub hqHZ htail using 1
+    all_goals ring
   have hqr4 : q ∣ r.natAbs ^ 4 := by
     simpa [Int.natAbs_pow] using Int.natCast_dvd.mp hqR4
   have hqr : q ∣ r.natAbs := hqPrime.dvd_of_dvd_pow hqr4
@@ -246,7 +247,8 @@ theorem five_not_dvd_H (p : GoldenZeroSectorCandidate) :
   have hdiff := five_dvd_goldenFifthSndFactor_sub_norm_sq
     (⟨p.r, p.s⟩ : GoldenInt)
   have hnormSq : (5 : ℤ) ∣ goldenNorm ⟨p.r, p.s⟩ ^ 2 := by
-    convert dvd_sub hH hdiff using 1 <;> ring
+    convert dvd_sub hH hdiff using 1
+    all_goals ring
   have hnorm : (5 : ℤ) ∣ goldenNorm ⟨p.r, p.s⟩ :=
     (show Prime (5 : ℤ) by norm_num).dvd_of_dvd_pow hnormSq
   apply p.five_not_dvd_b

--- a/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorInversion.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorInversion.lean
@@ -6,31 +6,41 @@ Authors: D. and Wise Wolf.
 
 import DkMath.FLT.Five.SignedGoldenZeroSector
 
+/-!
+# Certified inversion of the zero-sector equation
+
+Set `X = 2*r+s`, `U = X^2+5*s^2`, `W = 4*d^5`, and
+`A = U-W`, `B = U+W`. The diagonal quartic identity and the tenth-power split
+give `A*B = 4*Q^5` for `Q = 5^5*c^8`, while `B = A+8*d^5` records their exact
+separation. `GoldenZeroSectorCandidate` retains every positivity, coprimality,
+norm, and source equation needed to certify this transformation.
+-/
+
 #print "file: DkMath.FLT.Five.SignedGoldenZeroSectorInversion"
 
 namespace DkMath.FLT.Five
 
-/-- Diagonal coordinate for the quartic second-coordinate factor. -/
+/-- The diagonal coordinate `X = 2*r+s`. -/
 def zeroSectorX (r s : ℤ) : ℤ :=
   2 * r + s
 
-/-- Positive diagonal sum appearing in the zero-sector inversion. -/
+/-- The positive quadratic quantity `U = X^2+5*s^2`. -/
 def zeroSectorU (r s : ℤ) : ℤ :=
   zeroSectorX r s ^ 2 + 5 * s ^ 2
 
-/-- Square root of the tenth-power contribution after multiplying by sixteen. -/
+/-- The quantity `W = 4*d^5` supplied by `|H(r,s)| = d^10`. -/
 def zeroSectorW (d : ℕ) : ℤ :=
   4 * (d : ℤ) ^ 5
 
-/-- Lower factor produced by the discriminant-square inversion. -/
+/-- The lower inversion factor `A = U-W`. -/
 def zeroSectorA (r s : ℤ) (d : ℕ) : ℤ :=
   zeroSectorU r s - zeroSectorW d
 
-/-- Upper factor produced by the discriminant-square inversion. -/
+/-- The upper inversion factor `B = U+W`. -/
 def zeroSectorB (r s : ℤ) (d : ℕ) : ℤ :=
   zeroSectorU r s + zeroSectorW d
 
-/-- Natural fifth-power mass owned by the two inversion factors. -/
+/-- The fifth-power mass `Q = 5^5*c^8` in `A*B = 4*Q^5`. -/
 def zeroSectorQ (c : ℕ) : ℕ :=
   5 ^ 5 * c ^ 8
 

--- a/lean/dk_math/DkMath/FLT/Five/SignedSquareGoldenExceptional.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SignedSquareGoldenExceptional.lean
@@ -11,6 +11,18 @@ import DkMath.FLT.Five.SquareGoldenBridge
 
 namespace DkMath.FLT.Five
 
+/-!
+# The common signed square-to-norm packet
+
+Both signed five-adic orientations are represented by integral coordinates `M,N` with
+
+`GoldenNorm M N = 5*b^5`, `M-2N = 5^8*a^10`,
+
+and a retained square discriminant.  The sign of `N` distinguishes difference from sum
+factorization; the norm and boundary formulas are otherwise common.  This packet is the
+input from which the unique visible ramified factor above five is removed.
+-/
+
 /-- The sum residual is the golden norm with a negative cross-beam coordinate. -/
 theorem sumGN5_eq_goldenNorm_signed (u v : ℕ) :
     GoldenNorm
@@ -180,7 +192,7 @@ noncomputable def signedSquareGoldenExceptionalPacket_of_normalForm
   signedSquareGoldenExceptionalPacket_of_powerSplit
     (signedFiveAdicPowerSplit_of_normalForm hNF)
 
-/-- Remaining kernel after the signed five-adic and square-golden reductions meet. -/
+/-- Receiver contract for contradictions stated on the common signed square/norm packet. -/
 abbrev SignedSquareGoldenExceptionalCore : Prop :=
   ∀ {u v w : ℕ}, SignedSquareGoldenExceptionalPacket u v w → False
 

--- a/lean/dk_math/DkMath/FLT/Five/SquareGoldenBridge.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SquareGoldenBridge.lean
@@ -10,7 +10,21 @@ import DkMath.FLT.Five.NormalForm
 
 namespace DkMath.FLT.Five
 
-/-- The golden-ratio norm form in the integral basis `1, φ`. -/
+/-!
+# From the fifth cyclotomic factor to a quadratic norm
+
+The endpoint-square coordinates
+
+`m = (g+y)^2 + y^2`, `n = (g+y)*y`
+
+rewrite `GN5 g y` as `m^2 + m*n - n^2`.  Diagonalizing this norm gives the
+discriminant-five identity `4N = (2m+n)^2 - 5n^2`.  This is the algebraic bridge from
+the elementary cyclotomic factorization to the coordinate order introduced in
+`GoldenOrder.lean`; no number-field identification is needed at this stage.
+-/
+
+/-- The binary quadratic form `m^2 + m*n - n^2`, later realized as the norm of
+`m+n*φ` in the coordinate order with `φ^2=φ+1`. -/
 def GoldenNorm (m n : ℤ) : ℤ :=
   m ^ 2 + m * n - n ^ 2
 

--- a/lean/dk_math/DkMath/FLT/Five/SquareGoldenNormalForm.lean
+++ b/lean/dk_math/DkMath/FLT/Five/SquareGoldenNormalForm.lean
@@ -10,6 +10,15 @@ import DkMath.FLT.Five.SquareGoldenBridge
 
 namespace DkMath.FLT.Five
 
+/-!
+# Simultaneous square and quadratic-norm data
+
+The Branch-B fifth-power normal form is lifted to endpoint-square coordinates.  The
+packet preserves both `GoldenNorm M N = b^5` and an independent square discriminant,
+so the later signed five-adic route can enter the quadratic order without losing the
+original gap, positivity, or coprimality provenance.
+-/
+
 /-- The endpoint-square mass coordinate. -/
 def SquareGoldenM (z y : ℕ) : ℤ :=
   (z : ℤ) ^ 2 + (y : ℤ) ^ 2

--- a/lean/dk_math/DkMath/FLT/Five/Standalone.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Standalone.lean
@@ -13,6 +13,14 @@ import Mathlib
 
 namespace DkMath.FLT.Five.Standalone
 
+/-!
+# Mathlib-only GN5 seed
+
+This deliberately small namespace repeats the basic equation and cyclotomic
+factorization without importing any DkMath module.  It is a comparison and portability
+surface, not the public proof of `DkMath.FLT.Five.FLT5Target`.
+-/
+
 /-- The exponent-five Fermat equation. -/
 def Fermat5Equation (x y z : ℕ) : Prop :=
   x ^ 5 + y ^ 5 = z ^ 5

--- a/lean/dk_math/DkMath/FLT/Five/Valuation.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Valuation.lean
@@ -11,7 +11,7 @@ import DkMath.FLT.Five.BranchB
 namespace DkMath.FLT.Five
 
 /-!
-# Exponent-five valuation checkpoint
+# Exponent-five valuation obstruction
 
 This module carries an independent `padicValNat` proof of the clean-channel
 obstruction:
@@ -21,7 +21,8 @@ complete fifth power  -> local load at least 5
 clean GN5 channel     -> local load at most 1
 ```
 
-No research-only valuation theorem is imported here.
+This is an independent proof of the same contradiction supplied directly in
+`CleanChannel.lean`; no research-only valuation theorem is imported here.
 -/
 
 /-- A prime divisor of a positive base contributes valuation at least five to its fifth power. -/

--- a/lean/dk_math/DkMath/FLT/Five/Valuation.lean
+++ b/lean/dk_math/DkMath/FLT/Five/Valuation.lean
@@ -58,6 +58,24 @@ theorem padicValNat_clean_body_upper_bound
     (@padicValNat_dvd_iff_le q (Fact.mk h.prime) (g * GN5 g y) 2 hBodyNe).mpr htwo
   exact h.not_sq_dvd_body hsq
 
+/--
+A clean prime occurs in the full body with valuation exactly one. Divisibility
+of the body gives the lower bound, while `not_sq_dvd_body` gives the upper bound.
+-/
+theorem padicValNat_clean_body_eq_one
+    {g y q : ℕ}
+    (h : CleanGN5Channel g y q) :
+    padicValNat q (g * GN5 g y) = 1 := by
+  letI : Fact (Nat.Prime q) := ⟨h.prime⟩
+  have hBodyNe : g * GN5 g y ≠ 0 := by
+    intro hzero
+    apply h.not_sq_dvd_body
+    rw [hzero]
+    exact dvd_zero _
+  apply Nat.le_antisymm (padicValNat_clean_body_upper_bound h)
+  exact (@padicValNat_dvd_iff_le q (Fact.mk h.prime)
+    (g * GN5 g y) 1 hBodyNe).mp (by simpa using h.dvd_body)
+
 /-- The clean-channel contradiction, proved independently through `padicValNat`. -/
 theorem counterexample_false_of_clean_GN5Channel_by_padicValNat
     {x y z q : ℕ}
@@ -73,9 +91,9 @@ theorem counterexample_false_of_clean_GN5Channel_by_padicValNat
   have hqDivX : q ∣ x := hClean.prime.dvd_of_dvd_pow hqDivPow
   have hlower : 5 ≤ padicValNat q (x ^ 5) :=
     padicValNat_lower_bound_d5 hPack.hx hClean.prime hqDivX
-  have hupper : padicValNat q (Body5 (z - y) y) ≤ 1 := by
-    simpa [Body5] using padicValNat_clean_body_upper_bound hClean
-  rw [hBodyEq] at hupper
+  have hexact : padicValNat q (Body5 (z - y) y) = 1 := by
+    simpa [Body5] using padicValNat_clean_body_eq_one hClean
+  rw [hBodyEq] at hexact
   omega
 
 end DkMath.FLT.Five

--- a/lean/dk_math/DkMath/FLT/Five/docs/impl-flt5-cp-006-docstring.txt
+++ b/lean/dk_math/DkMath/FLT/Five/docs/impl-flt5-cp-006-docstring.txt
@@ -1,5 +1,52 @@
 # FLT5 cp-006 — GN5 / FLT5 mathematician-facing docstring and explanatory API pass
 
+*complite*
+
+完了しました。FLT5 cp-006 は、カテゴリ全体を横断する Outcome B として仕上げています。🎗️
+
+- コミット: `6c2c2a49 docs(flt5): document the closed exponent-five proof`
+- ブランチ: `hackathon/publish-gn5-flt5-260721-v0`
+- 変更: 36 files、496 insertions、100 deletions
+- worktree: clean、origin より 1 commit ahead
+
+主な成果:
+
+- GN5 から五進分解、GoldenInt、unit sector、zero-sector inversion、factorization、strict descent、最終定理まで、全主要モジュールへ英語 module docstring を追加
+- [Main.lean](/lean/dk_math/DkMath/FLT/Five/Main.lean) に証明経路と公開 endpoint の説明を配置
+- 正確なスコープを明記:
+  - 正の自然数
+  - 指数 5
+  - 一般 FLT、歴史的新規性、外部査読・受理は主張しない
+- `GoldenInt` は `φ² = φ + 1` による直接座標モデル `ℤ[φ]` であり、体の整数環との形式的同型は主張しないと明記
+- unit sector は幾何学的な角度ではなく、5 個の代数的 unit class であると明記
+- “future”, “remaining obstruction”, “missing theorem” など、証明完了後に不正確となった checkpoint-era 文言を更新
+- 既存証明を再利用する canonical helper theorem を 8 個追加:
+  - GN5 標準恒等式 3 個
+  - `φ`、共役、ノルム、整数埋め込みの基本式 5 個
+- [CheckAxioms.lean](/lean/dk_math/DkMathTest/FLT/Five/CheckAxioms.lean) に追加 API の公理監査を登録
+- 新しい `sorry`、`admit`、`axiom`、`native_decide` はありません
+- 独自公理の混入なし。公理監査結果は既存と同じ標準的な `propext`、`Classical.choice`、`Quot.sound` の範囲です
+
+検証結果:
+
+- `lake build DkMath.FLT.Five` — 成功、8281 jobs
+- `lake build DkMath.FLT.Five.Main` — 成功、8280 jobs
+- `lake build DkMathTest.FLT.Five.CheckAxioms` — 成功、8283 jobs
+- `git diff --check` — 成功
+
+cp-006 の説明上の未解決事項はありません。次の最小ドキュメント checkpoint を設けるなら、公開 theorem/API の索引を README 形式で生成する作業になります。今回、証明本体の構造には不要な変更を加えていません。
+
+GN5_eq_homogeneous_cyclotomic
+GN5_eq_gap_mul_add_five_mul_y_pow_four
+GN5_eq_g_pow_four_add_five_mul
+golden_phi_sq
+goldenConj_phi
+goldenNorm_phi
+goldenConj_ofInt
+goldenNorm_ofInt
+
+---
+
 Date: 2026-07-21  
 Repository: `Deskuma/dkmath`  
 Working branch: `hackathon/publish-gn5-flt5-260721-v0`  

--- a/lean/dk_math/DkMath/FLT/Five/docs/impl-flt5-cp-006-docstring.txt
+++ b/lean/dk_math/DkMath/FLT/Five/docs/impl-flt5-cp-006-docstring.txt
@@ -1,0 +1,699 @@
+# FLT5 cp-006 — GN5 / FLT5 mathematician-facing docstring and explanatory API pass
+
+Date: 2026-07-21  
+Repository: `Deskuma/dkmath`  
+Working branch: `hackathon/publish-gn5-flt5-260721-v0`  
+Lean workspace: `lean/dk_math`
+
+## 0. Mission
+
+Strengthen the source-level mathematical exposition of the complete exponent-five development.
+
+The primary deliverable is not a new proof route. The current Lean declarations are already the source of truth. The task is to make the existing route readable to a mathematician who opens the Lean files directly and wants to understand:
+
+- what each object represents in standard mathematical language;
+- why each hypothesis is present;
+- how the declaration participates in the proof;
+- which statement is an algebraic identity, a reduction, a local obstruction, a packet invariant, or a final closure;
+- which surrounding mathematical interpretations are contextual only and which are formalized in Lean.
+
+Improve module documentation and declaration docstrings throughout the GN5 / FLT5 tower. Where a short canonical helper theorem would materially clarify the mathematics, add it and use it in the exposition or proof flow when appropriate.
+
+Act autonomously. Inspect the whole current implementation, identify explanatory gaps, choose the exact wording, theorem names, and file-local placement, and implement the best coherent pass.
+
+## 1. Current theorem boundary
+
+The public endpoint is the positive-natural exponent-five statement encoded in:
+
+```lean
+DkMath.FLT.Five.flt5Target
+DkMath.FLT.Five.fermatFive_no_positive_solution
+```
+
+Its exact scope is:
+
+$$x,y,z\in\mathbb N_{>0}\Longrightarrow x^5+y^5\ne z^5.$$
+
+Do not broaden this to nonzero integers or general exponents.
+
+The final unconditional public chain includes:
+
+```lean
+goldenZeroSectorFactorExclusion
+goldenZeroSectorArithmeticExclusion
+flt5Target
+fermatFive_no_positive_solution
+```
+
+The repository presents this as a Lean-checked implementation under its explicit theorem contract. Do not write that external peer review or mathematical-community acceptance has been completed.
+
+## 2. Read before editing
+
+Read the current branch, not only historical reports.
+
+Required source inspection:
+
+```text
+DkMath/FLT/Five.lean
+DkMath/FLT/Five/*.lean
+DkMathTest/FLT/Five/CheckAxioms.lean
+```
+
+Required project context:
+
+```text
+DkMath/FLT/Five/docs/FLT5_IMPLEMENTS_PLAN.md
+DkMath/FLT/Five/docs/flt5-cp-001-to-cp-004-summary.md
+DkMath/FLT/Five/docs/repo-flt5-cp-005-final.md
+DkMath/FLT/Five/docs/impl-flt5-cp-005-00-final-boss-master.txt
+DkMath/FLT/Five/docs/impl-flt5-cp-005-01-certified-inversion-factorization.txt
+DkMath/FLT/Five/docs/impl-flt5-cp-005-02-ultra-inference-descent.txt
+DkMath/FLT/Five/docs/impl-flt5-cp-005-03-autonomous-closure-flt5.txt
+```
+
+Also inspect PR #56 when useful for chronology and design decisions:
+
+```text
+https://github.com/Deskuma/dkmath/pull/56
+```
+
+Historical checkpoint documents explain why objects were introduced, but current Lean source decides what is actually proved.
+
+## 3. Exposition standard
+
+All new source documentation should be in English, matching the existing Lean files.
+
+For each conceptual module, add or strengthen a module doc block of the form:
+
+```lean
+/-!
+# ...
+
+...
+-/
+```
+
+A good module document should normally explain:
+
+1. the standard mathematical object represented by the module;
+2. the input inherited from the previous layer;
+3. the exact output passed to the next layer;
+4. the main formulas or invariants;
+5. why this layer is necessary;
+6. the formal scope and any important non-claims.
+
+For important public declarations, replace one-line labels with useful mathematical docstrings. A load-bearing docstring should answer some combination of:
+
+- What does this definition encode?
+- How should the coordinates be interpreted?
+- Why is this hypothesis needed?
+- What is the standard mathematical name or analogue?
+- What contradiction or reduction does the theorem provide?
+- Which later declaration consumes it?
+- Is the declaration computational, structural, existential, or a public receiver contract?
+
+Use formulas where they improve comprehension. Avoid repeating the Lean signature in prose without adding meaning.
+
+Small simp lemmas, obvious coordinate projections, internal instances, and private proof plumbing do not need large comments. Do not inflate every line with boilerplate.
+
+## 4. Mathematical language policy
+
+Lead with standard mathematics. DkMath terminology may be given as a secondary interpretation.
+
+Preferred examples:
+
+- “homogeneous fifth cyclotomic factor” before “GN5 residual”;
+- “the order `ℤ[φ]` with `φ² = φ + 1`” before “golden world”;
+- “norm, conjugation, unit class, ramified factor above five, infinite descent” before project metaphors;
+- “local valuation-one prime divisor” before “clean channel”.
+
+Do not write promotional claims such as:
+
+```text
+AI proved FLT5
+FLT5 solved by DkMath
+new proof accepted
+complete external verification
+```
+
+Do not claim that a standard identification has been formalized when it has only been used as mathematical context.
+
+In particular, `GoldenInt` is implemented as a direct coordinate model of the integral order `ℤ[φ]`, with `φ² = φ + 1`. It is mathematically the familiar golden quadratic integer ring, but the code does not currently construct a field-level isomorphism with `𝒪_{ℚ(√5)}`. State this distinction clearly if the broader identification is mentioned.
+
+## 5. Global audit requirement
+
+Audit essentially the entire public GN5 / FLT5 source surface by category rather than mechanically following the list below.
+
+At minimum, inspect every public `def`, `abbrev`, `structure`, `inductive`, and `theorem` in:
+
+```text
+Basic.lean
+GN5.lean
+CleanChannel.lean
+BranchA.lean
+BranchB.lean
+Valuation.lean
+Provider.lean
+Reduction.lean
+NormalForm.lean
+SignedBranchA.lean
+SignedFiveAdic.lean
+SignedFiveAdicPowerSplit.lean
+SquareGoldenBridge.lean
+SquareGoldenNormalForm.lean
+SignedSquareGoldenExceptional.lean
+GoldenOrder.lean
+GoldenDivisibility.lean
+GoldenEuclidean.lean
+GoldenCoprimeFactor.lean
+GoldenFifthPowerCoordinates.lean
+SignedGoldenRamifierStripped.lean
+SignedGoldenConjugateCoprime.lean
+SignedGoldenFifthPower.lean
+SignedGoldenUnitClasses.lean
+GoldenUnitClassification.lean
+SignedGoldenSectorArithmetic.lean
+SignedGoldenZeroSector.lean
+SignedGoldenZeroSectorInversion.lean
+SignedGoldenZeroSectorFactorization.lean
+SignedGoldenZeroSectorDescent.lean
+SignedGoldenZeroSectorFinal.lean
+SignedGoldenClosure.lean
+Main.lean
+Standalone.lean
+```
+
+The implementation is large enough that the expected result is a category-wide pass, not a tiny hand-selected list.
+
+## 6. Category A — GN5 foundation and local obstruction
+
+Primary files:
+
+```text
+Basic.lean
+GN5.lean
+CleanChannel.lean
+BranchB.lean
+Valuation.lean
+Provider.lean
+Reduction.lean
+NormalForm.lean
+Standalone.lean
+```
+
+The documentation should make the following mathematical route immediately visible.
+
+Let `g = z - y`. Then:
+
+$$z^5-y^5=g\,GN5(g,y),$$
+
+where the gap-coordinate polynomial is:
+
+$$GN5(g,y)=g^4+5g^3y+10g^2y^2+10gy^3+5y^4.$$
+
+Explain that this is the usual homogeneous fifth cyclotomic quotient written in the local coordinate `z = g + y`:
+
+$$\frac{z^5-y^5}{z-y}=z^4+z^3y+z^2y^2+zy^3+y^4.$$
+
+The code should help a mathematician move between these two coordinate descriptions.
+
+Explain `CleanGN5Channel g y q` as a prime `q` satisfying:
+
+```text
+q is prime
+q divides GN5(g,y)
+q does not divide g
+q² does not divide GN5(g,y)
+```
+
+The mathematical content is that `q` enters the residual with local valuation exactly one and cannot be supplied by the gap. Consequently the full product `g * GN5(g,y)` cannot be a fifth power.
+
+Explain the two independent contradiction routes:
+
+```text
+direct square-divisibility argument
+padicValNat lower-bound / upper-bound argument
+```
+
+Explain the exceptional role of the prime five in the gcd reduction and why Branch B assumes `5 ∤ g`.
+
+### Canonical helper-theorem audit for Category A
+
+Do not add all of these blindly. Investigate whether each is absent, useful, non-duplicative, and naturally placed.
+
+1. A public bridge from gap coordinates to the standard homogeneous fifth cyclotomic factor, for example a theorem equivalent to:
+
+$$GN5(g,y)=(g+y)^4+(g+y)^3y+(g+y)^2y^2+(g+y)y^3+y^4.$$
+
+2. A reusable decomposition or congruence exposing:
+
+$$GN5(g,y)\equiv 5y^4\pmod g.$$
+
+The current proof route contains this algebra inside a local proof. A named theorem may substantially clarify why five is the only exceptional common prime.
+
+3. A reusable decomposition or congruence exposing:
+
+$$GN5(g,y)\equiv g^4\pmod 5.$$
+
+This is the structural reason `5 ∤ g` implies `5 ∤ GN5(g,y)`.
+
+4. An exact valuation-one theorem for a clean channel, on `GN5` and/or the full body, if it can be stated without awkward extra assumptions and if it improves the mathematical surface beyond the existing `≤ 1` theorem.
+
+5. Positivity or nonzero lemmas for `GN5` only when they remove repeated local arithmetic or make valuation statements cleaner.
+
+6. A compact equivalence or reconstruction theorem connecting `Fermat5Equation` and the local body equation, if the existing one-way lemmas leave a genuine explanatory gap.
+
+Prefer congruence or factorization statements with standard mathematical meaning over ad hoc wrappers.
+
+## 7. Category B — signed routing and exact five-adic normal form
+
+Primary files:
+
+```text
+BranchA.lean
+SignedBranchA.lean
+SignedFiveAdic.lean
+SignedFiveAdicPowerSplit.lean
+```
+
+Update stale checkpoint-era comments. For example, comments describing a “future” Branch-A refuter are no longer current and must be rewritten to describe the completed route.
+
+Explain why a primitive positive candidate is routed into one of two signed orientations:
+
+```text
+difference gap divisible by five
+sum gap divisible by five
+```
+
+Explain the role of the mod-25 classification and why the residual has:
+
+$$v_5(\text{residual})=1.$$
+
+Explain the common packet fields in mathematical language:
+
+```text
+carrier * residual = distinguished^5
+5 divides the carrier
+5 divides the distinguished fifth-power base
+residual ≡ 5 mod 25
+v₅(residual) = 1
+v₅(carrier) ≡ 4 mod 5
+```
+
+Explain the exact power split:
+
+$$\text{carrier}=5^4a^5,\qquad \text{residual}=5b^5,$$
+
+and the coprimality retained after removing the visible factor five.
+
+`SumGN5` requires especially careful explanation: it is the positive natural residual for factoring `u^5+v^5` by `u+v`, expressed piecewise only to avoid signed natural subtraction. The piecewise implementation is representational, not a mathematical asymmetry.
+
+### Canonical helper-theorem audit for Category B
+
+Investigate:
+
+- a symmetry theorem for `SumGN5`, if absent and easy;
+- a standard signed or integer polynomial form for the sum residual, if it materially clarifies the piecewise natural definition;
+- compact packet projection theorems only where structure fields are otherwise difficult to discover;
+- removal of duplicated local decompositions by exposing canonical named lemmas.
+
+Do not redesign the packet hierarchy.
+
+## 8. Category C — square/golden bridge and the quadratic order
+
+Primary files:
+
+```text
+SquareGoldenBridge.lean
+SquareGoldenNormalForm.lean
+SignedSquareGoldenExceptional.lean
+GoldenOrder.lean
+GoldenDivisibility.lean
+GoldenEuclidean.lean
+GoldenCoprimeFactor.lean
+GoldenFifthPowerCoordinates.lean
+SignedGoldenRamifierStripped.lean
+SignedGoldenConjugateCoprime.lean
+SignedGoldenFifthPower.lean
+```
+
+The source should explain the transition from GN5 to the quadratic order in ordinary mathematical terms.
+
+Document the coordinate model:
+
+$$\varphi^2=\varphi+1,$$
+
+$$a+b\varphi\longleftrightarrow \langle a,b\rangle,$$
+
+with conjugation:
+
+$$\varphi\mapsto1-\varphi,$$
+
+and norm:
+
+$$N(a+b\varphi)=a^2+ab-b^2.$$
+
+Explain how the square-coordinate transformation rewrites the GN5 expression as this norm form, and how the discriminant-five identity enters.
+
+Explain:
+
+- why a visible ramified factor above five must be removed;
+- what `goldenSqrtFive` and `goldenTau` represent;
+- why `N(goldenTau)=5`;
+- how relative primality of an element and its conjugate is certified;
+- why coprime factors of a fifth power become fifth powers up to a unit in the Euclidean domain;
+- why the Euclidean structure is established through strict decrease of the absolute norm.
+
+The `GoldenEuclidean.lean` module should be readable as a proof that the chosen coordinate ring is norm-Euclidean, not merely as a collection of rounding lemmas.
+
+### Canonical helper-theorem audit for Category C
+
+Investigate whether a small set of standard bridge lemmas would make the ring self-explanatory:
+
+```text
+φ² = φ + 1
+conj(φ) = 1 - φ
+N(φ) = -1
+conj(integer embedding) = integer embedding
+N(integer embedding) = integer square
+```
+
+Also inspect whether `goldenTau`, `goldenSqrtFive`, their conjugates, product, and norm already expose all identities needed to explain ramification cleanly.
+
+Add only canonical facts that clarify the mathematical model or remove repeated coordinate calculations. Do not create a parallel number-field abstraction.
+
+## 9. Category D — units modulo fifth powers and sector elimination
+
+Primary files:
+
+```text
+GoldenUnitClassification.lean
+SignedGoldenUnitClasses.lean
+GoldenFifthPowerCoordinates.lean
+SignedGoldenSectorArithmetic.lean
+```
+
+Explain the elementary unit descent:
+
+- units are detected by norm `±1`;
+- multiplication by `φ` or its integral inverse changes coordinates;
+- the measure `|a|+|b|` strictly decreases outside the base cases;
+- strong induction reduces every unit to the orbit generated by `±φ`;
+- modulo fifth powers, only five representatives `φ^i`, `i ∈ Fin 5`, remain.
+
+Explain why the sign is absorbed into a fifth power because the exponent is odd.
+
+Then explain the sector argument:
+
+```text
+sector 0 remains
+sectors 1, 2, 3, 4 force five into the norm of the fifth-power base
+the packet independently says that norm is prime to five
+therefore every nonzero sector is impossible
+```
+
+Make it clear that “sector” here means a unit class modulo fifth powers, not an analytic or geometric sector.
+
+### Canonical helper-theorem audit for Category D
+
+Inspect whether the public classification theorem is easy to understand from its current signature. Add summary lemmas only if needed to expose the standard statement “every unit is `±φ^n`” or its exact implemented equivalent, without introducing a stronger claim than the code proves.
+
+Document `GoldenUnitFifthClass` and `GoldenUnitClassesModFifth` thoroughly; these are central mathematical declarations, not implementation details.
+
+## 10. Category E — zero sector, inversion, factorization, and descent
+
+Primary files:
+
+```text
+SignedGoldenZeroSector.lean
+SignedGoldenZeroSectorInversion.lean
+SignedGoldenZeroSectorFactorization.lean
+SignedGoldenZeroSectorDescent.lean
+SignedGoldenZeroSectorFinal.lean
+SignedGoldenClosure.lean
+```
+
+This category needs the strongest documentation pass. The current files contain many small docstrings, but a mathematician needs a continuous explanation of the descent.
+
+Explain the zero-sector input in a compact invariant form. At the relevant stage the packet supplies, up to the exact signs encoded in the structures:
+
+$$s\,H(r,s)=-5^6a^{10},$$
+
+$$N(r,s)=\pm b,$$
+
+$$\gcd(|r|,|s|)=1,$$
+
+$$5\nmid b.$$
+
+Explain the exact split:
+
+$$|s|=5^6c^{10},\qquad H(r,s)=d^{10},$$
+
+and the roles of positivity, parity, coprimality, and the exclusion of five.
+
+### Inversion and factorization
+
+Explain the diagonal coordinates and the difference-of-squares reconstruction. Definitions such as:
+
+```text
+zeroSectorX
+zeroSectorU
+zeroSectorW
+zeroSectorA
+zeroSectorB
+zeroSectorQ
+```
+
+need docstrings that state the actual formula, not only “upper factor” or “diagonal coordinate”.
+
+Explain what the odd/even factor branches mean and why the branch split is exhaustive.
+
+The factorization file should have a module-level roadmap from the inversion packet to `GoldenZeroSectorFactorPacket`.
+
+### Recursive descent
+
+Explain the golden lift:
+
+$$T(r,s)=(r^2+rs+s^2,s^2),$$
+
+implemented by `goldenZeroSectorLift`.
+
+State clearly:
+
+$$N(T(r,s))=H(r,s).$$
+
+Explain why this lift is chosen: it turns the quartic invariant into a norm while keeping the visible coordinate square-shaped.
+
+Explain the recursive packet invariant:
+
+$$|s|=5t^5,\qquad H(r,s)=D^5,\qquad \gcd(|r|,|s|)=1,\qquad 5\nmid N(r,s).$$
+
+Explain the re-entry sequence:
+
+```text
+lift and conjugate are relatively prime
+→ lift is a fifth power up to a unit
+→ nonzero unit sectors are impossible
+→ lift is an honest fifth power
+→ the fifth root inherits the same packet shape
+→ its second-coordinate absolute value is strictly smaller
+→ strong induction gives contradiction
+```
+
+The measure theorem is the heart of the proof. Its docstring should explain what is decreasing and why this is sufficient for well-founded descent.
+
+### Canonical helper-theorem audit for Category E
+
+Investigate whether readers need:
+
+- a single public theorem summarizing all defining identities of the lift;
+- a concise constructor/projection theorem exposing the recursive invariant created from a candidate;
+- a theorem naming the preservation of the packet shape separately from strict decrease;
+- formula-oriented docstrings for every public inversion coordinate;
+- additional branch summary lemmas in the factorization layer.
+
+Avoid adding wrappers that merely restate structure fields without improving discoverability.
+
+## 11. Category F — closure and public theorem surface
+
+Primary files:
+
+```text
+SignedGoldenClosure.lean
+SignedGoldenZeroSectorFinal.lean
+Main.lean
+DkMath/FLT/Five.lean
+DkMathTest/FLT/Five/CheckAxioms.lean
+```
+
+The public surface must be understandable without reading every internal packet.
+
+Strengthen the documentation of:
+
+```lean
+FLT5Target
+flt5Target_of_unitClasses_of_zeroArithmetic
+flt5Target_of_zeroArithmetic
+goldenZeroSectorFactorExclusion
+goldenZeroSectorArithmeticExclusion
+flt5Target
+fermatFive_no_positive_solution
+```
+
+Explain which declarations are conditional receiver interfaces retained for reuse and which are unconditional endpoints.
+
+Add or improve a module roadmap in `Main.lean` before the public declarations, not only a trailing comment after them.
+
+The final ordinary-argument theorem docstring must state:
+
+- domain: positive natural numbers;
+- equation excluded;
+- it is a wrapper around `flt5Target`;
+- it does not expose a general-exponent theorem.
+
+Review `DkMath/FLT/Five.lean` as the compact import surface and add a useful module doc if absent.
+
+Update `CheckAxioms.lean` only when new public helper theorems are sufficiently central to merit explicit inspection. Do not add every documentation helper to the audit list.
+
+## 12. Stale-language audit
+
+Search all source comments for checkpoint-era or future-tense wording that is now false or misleading.
+
+Examples include phrases such as:
+
+```text
+future dedicated refuter
+remaining missing theorem
+will extract
+next obstruction
+current research obligation
+conditional final target
+```
+
+Some conditional interfaces remain intentionally reusable, so do not delete them. Rewrite their docstrings to explain their present role in the completed tower.
+
+Do not erase historical information from the implementation reports. This audit concerns current Lean source comments and docstrings.
+
+## 13. Rules for adding helper lemmas
+
+A helper theorem is justified when at least one of these holds:
+
+1. it states a canonical standard identity hidden inside a local proof;
+2. it connects two coordinate systems used by mathematicians;
+3. it exposes a congruence or valuation interpretation repeatedly used later;
+4. it gives a named preservation or descent fact central to the proof narrative;
+5. it removes duplicated algebra from multiple files;
+6. it makes the module documentation link to a precise Lean declaration.
+
+A helper theorem is not justified when it:
+
+- only aliases an existing theorem under a near-duplicate name;
+- merely restates one structure field;
+- exists only to make the report longer;
+- broadens the mathematical claim;
+- causes architectural refactoring unrelated to documentation;
+- introduces a new abstraction hierarchy.
+
+Prefer short proofs using existing results. Preserve existing public names and theorem statements.
+
+## 14. Expected work style
+
+This is not a transcription task.
+
+Codex should:
+
+1. inspect the entire tower;
+2. create a coherent mathematical narrative for each layer;
+3. identify stale and underspecified comments;
+4. propose and implement useful canonical helper lemmas;
+5. update proofs to reuse those lemmas when this reduces duplication;
+6. preserve dependency direction;
+7. build and inspect the final public surface;
+8. report both changes made and explanatory gaps deliberately left untouched.
+
+Do not stop after editing only `GN5.lean` and `Main.lean`.
+
+## 15. Outcome branches
+
+### Outcome A — documentation-only closure
+
+Use this when the existing theorem surface already contains every canonical identity required for explanation.
+
+Deliver:
+
+- module docs;
+- strengthened public docstrings;
+- stale-language corrections;
+- no new mathematical declarations.
+
+### Outcome B — documentation plus thin explanatory API
+
+Use this when canonical identities or congruence bridges are currently trapped inside local proofs.
+
+Deliver:
+
+- all Outcome A work;
+- a small set of named helper theorems;
+- proof reuse where natural;
+- audit updates only for genuinely central new public lemmas.
+
+This is the expected outcome if the GN5 congruence and golden-order bridge gaps are confirmed.
+
+### Outcome C — structural documentation blocker
+
+Use this only if the source cannot be explained honestly without a nontrivial refactor or a new mathematical result.
+
+Do not perform the large refactor. Document:
+
+- the exact blocker;
+- affected files and declarations;
+- the smallest proposed future checkpoint.
+
+Continue all independent documentation work outside the blocker.
+
+## 16. Verification
+
+Run the relevant Lean targets after editing:
+
+```bash
+cd lean/dk_math
+lake build DkMath.FLT.Five
+lake build DkMath.FLT.Five.Main
+lake build DkMathTest.FLT.Five.CheckAxioms
+```
+
+Also run:
+
+```bash
+git diff --check
+```
+
+No new `sorry`, `admit`, project-specific axiom, or `native_decide`.
+
+Do not treat existing unrelated warnings outside this target as a cp-006 failure.
+
+## 17. Completion report
+
+Return a report containing:
+
+```text
+checkpoint: cp-006
+branch and commit
+files modified
+module docs added
+public docstrings strengthened
+stale comments corrected
+helper theorems added
+existing proofs refactored to use them
+public API changes
+axiom-audit changes
+build targets
+remaining explanatory gaps
+recommended next documentation checkpoint
+```
+
+Include a categorized list of helper theorems actually added, with one sentence explaining why each improves mathematical readability.
+
+The completion criterion is not “more comments”. It is:
+
+> A mathematician can start at `GN5.lean`, follow the source through the five-adic and golden-order layers, reach the strict descent and final theorem, and understand why each transition is mathematically legitimate without reconstructing the entire narrative from checkpoint reports.

--- a/lean/dk_math/DkMath/FLT/Five/docs/repo-flt5-cp-006-docstring.md
+++ b/lean/dk_math/DkMath/FLT/Five/docs/repo-flt5-cp-006-docstring.md
@@ -78,3 +78,61 @@ Lean linter warning を修正した。
 
 cp-006 の docstring/API polish に加えて、同カテゴリー内で観測されていた
 `unnecessarySeqFocus` および `unnecessarySimpa` warning も除去された。
+
+---
+
+## High-value explanatory API follow-up
+
+cp-006 の付加価値作業として、数学者がエディタ上の API と公理監査だけで
+証明経路と正確な射程を読めるよう、次の三点を追加した。
+
+### Exact clean-channel valuation
+
+`Valuation.lean` に次の公開 theorem を追加した。
+
+```lean
+theorem padicValNat_clean_body_eq_one
+    {g y q : ℕ}
+    (h : CleanGN5Channel g y q) :
+    padicValNat q (g * GN5 g y) = 1
+```
+
+これは新しい証明路線ではなく、`CleanGN5Channel.dvd_body` が与える
+valuation lower bound と、`padicValNat_clean_body_upper_bound` が与える upper
+bound を束ねた canonical API である。valuation による clean-channel
+contradiction も、この theorem を再利用して `5 ≤ valuation` と
+`valuation = 1` を直接対立させる形へ更新した。
+
+### Final public theorem docstrings
+
+`Main.lean` の `flt5Target` と `fermatFive_no_positive_solution` に、次を
+theorem-level docstring として明記した。
+
+- `x`, `y`, `z` は正の自然数
+- `Fermat5Equation x y z` は `x^5 + y^5 = z^5` を表す
+- ordinary-argument theorem は `flt5Target` の wrapper
+- 一般指数版および任意の符号付き整数版ではない
+
+### CheckAxioms inspection entry point
+
+`CheckAxioms.lean` に module doc を追加し、ファイルが proof module ではなく
+axiom-surface inspection entry point であることを明記した。さらに監査項目を
+次の大見出しで整理した。
+
+- GN5 foundation
+- clean-channel obstruction
+- five-adic routing
+- golden order
+- unit classification
+- zero-sector descent
+- public closure
+
+`padicValNat_clean_body_eq_one` も `#print axioms` の監査対象へ追加した。
+
+検証:
+
+- `lake build DkMath.FLT.Five.Valuation` — 成功、8252 jobs
+- `lake build DkMath.FLT.Five` — 成功
+- `lake build DkMath.FLT.Five.Main` — 成功
+- `lake build DkMathTest.FLT.Five.CheckAxioms` — 成功
+- `git diff --check` — 成功

--- a/lean/dk_math/DkMath/FLT/Five/docs/repo-flt5-cp-006-docstring.md
+++ b/lean/dk_math/DkMath/FLT/Five/docs/repo-flt5-cp-006-docstring.md
@@ -1,0 +1,80 @@
+# Report: FLT5 cp-006
+
+## docstring
+
+必須1は impl ファイル完了状態が解りやすいように impl 内にステータスと共に記載。
+以下 Codex 報告
+
+---
+
+必須2の対応を完了しました。
+
+[SignedGoldenZeroSectorDescent.lean](/lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean) の次の4定理に theorem-level docstring を追加しています。
+
+- `goldenZeroSectorLift_norm`
+- `GoldenZeroSectorDescentPacket.fifthRoot_measure_lt`
+- `GoldenZeroSectorDescentPacket.strictDescent`
+- `goldenZeroSectorDescentPacket_false`
+
+明記した内容:
+
+- well-founded measure は第二座標の絶対値 `|s|`
+- fifth root の第二座標が次 packet の visible coordinate になる
+- coprimality、fifth-power shape、norm condition が保存される
+- strict inequality により `Nat.strong_induction_on` が適用できる
+- 最終 FLT5 theorem を参照しない非循環な降下である
+
+検証:
+
+- `lake build DkMath.FLT.Five.SignedGoldenZeroSectorDescent` — 成功、8273 jobs
+- `git diff --check` — 成功
+- worktree clean
+
+コミット:
+
+```text
+c4b6664b docs(flt5): explain the strict descent heart
+```
+
+ユーザー側の cp-006 完了報告コミットも保持されています。
+
+```text
+85657cac Upd: docs: report: FLT5 cp-006 — GN5 / FLT5 mathematician-facing docstring and explanatory API pass
+```
+
+現在、ブランチは origin より 2 commits ahead です。
+
+---
+
+## Linter warning cleanup
+
+cp-006 の最終 polish として、FLT5 全体ビルドで報告されていた軽微な
+Lean linter warning を修正した。
+
+対象:
+
+- `GoldenUnitClassification.lean`
+- `SignedGoldenSectorArithmetic.lean`
+- `SignedGoldenZeroSector.lean`
+- `SignedGoldenZeroSectorInversion.lean`
+- `SignedGoldenZeroSectorFactorization.lean`
+- `SignedGoldenZeroSectorDescent.lean`
+
+修正内容:
+
+- 不要な sequential-goal focus と判定された `tac1 <;> tac2` を、
+  `all_goals` を用いた明示的な goal 処理へ変更
+- `unnecessarySimpa` が報告された一箇所を `simp` へ簡約
+- `set_option linter.unnecessarySeqFocus false` などの警告抑制は追加していない
+- theorem statement、公開 API、数学的証明内容に変更はない
+
+検証:
+
+- `lake build DkMath.FLT.Five` — 成功、8281 jobs、対象 linter warning なし
+- `lake build DkMathTest.FLT.Five.CheckAxioms` — 成功
+- `git diff --check` — 成功
+
+結果:
+
+cp-006 の docstring/API polish に加えて、同カテゴリー内で観測されていた
+`unnecessarySeqFocus` および `unnecessarySimpa` warning も除去された。

--- a/lean/dk_math/DkMath/Hackathon/README.md
+++ b/lean/dk_math/DkMath/Hackathon/README.md
@@ -1,124 +1,176 @@
-# Hackathon: OpenAI Build Week - 260715 @ devpost
+# Hackathon: OpenAI Build Week - 260715 @ Devpost
 
 > [!IMPORTANT]
-> **Explore the complete project record**
+> **OpenAI Build Week project entry point**
 >
-> Read the mathematical contract, Codex instructions, implementation
-> checkpoints, verification reports, visualization pipeline, and final handoff:
+> This directory is the compact Lean-facing entrance to the submission.
+> The complete project record—including the mathematical contract, Codex
+> instructions, checkpoints, verification reports, visualization pipeline,
+> and post-video research update—is available here:
 >
 > **[Open the complete OpenAI Build Week project documentation](../../docs/hackathon/cosmic-formula-inversion-260715/README.md)**
 
-## A Demonstration of AI-Assisted Learning and Verifiable Research
-
-This project demonstrates how AI can be integrated into learning, education, and mathematical research while keeping every result reproducible and verifiable.
-
-Through a concrete development workflow and working artifacts, it explores the following questions:
-
-- How can AI support human understanding and exploration without replacing the learner's own reasoning?
-- How can educators use AI to create explanations, instructional materials, visualizations, and exercises?
-- How can mathematical ideas that emerge during learning be developed into reproducible research?
-- How can the Lean theorem prover and Codex be used to maintain, verify, and manage the accuracy of definitions, theorems, and proofs?
-- Can the accumulated results of AI-assisted learning and formal verification open new research paths toward unsolved problems?
-
-DkMath connects human mathematical insight, GPT-5.6 review, repository-scale implementation with Codex, machine verification with Lean, and the creation of visual learning materials into a single auditable workflow.
-
-This demo presents the complete process—from learning and exploration to implementation, verification, and explanation—as one compact practical experiment.
-
-## Educational Contents
-
-![gif](../../docs/hackathon/cosmic-formula-inversion-260715/visual/media/videos/cosmic_formula_scene/720p30/CosmicFormulaPrototype.gif)
-
-## Watch the Verified Mathematics in Motion
-
-The verified Lean example is transformed into a short animated learning
-experience for students, educators, and mathematical explorers.
-
-The animation shows how the finite prime set
-
-`{2, 3, 5, 7}`
-
-forms `P = 210`, how the Body and square Gap complete the Cosmic Formula
-boundary, and how the new factors `13` and `17` appear outside the original
-finite prime universe.
-
-▶️ **[Watch the Cosmic Formula animated learning prototype (mp4)](../../docs/hackathon/cosmic-formula-inversion-260715/visual/media/videos/cosmic_formula_scene/720p30/CosmicFormulaPrototype.mp4)**
-
-The animation explains the structure visually; the Lean files in this
-directory verify the mathematical claims.
-
 ## DkMath — Verifiable AI Mathematical Research
 
-A verifiable AI-assisted mathematical research project for the OpenAI Build Week Hackathon.
+DkMath is an experiment in human-directed, AI-assisted mathematical research
+with a mechanically checkable result surface.
 
-This project demonstrates a workflow in which:
+The working loop is:
 
-1. a mathematical structure is proposed and refined through human–AI dialogue;
-2. Codex investigates and implements the structure inside an existing Lean 4 library;
-3. Lean verifies the resulting theorem surface;
-4. the verified mathematics is transformed into an accessible visual demonstration.
+```text
+human mathematical direction
+→ GPT-5.6 reasoning, review, and scope control
+→ Codex repository investigation and implementation
+→ Lean verification
+→ reproducible explanation and publication artifacts
+```
 
-The main theme is the transition from a finite universe of known prime factors to a provably new prime factor, expressed through the DkMath Cosmic Formula, finite-prime escape, and the new GN5 extension.
+The AI systems help explore, implement, review, and communicate the work.
+Lean—not the AI-generated prose—is the verification gate for accepted theorem
+declarations.
 
-## How GPT-5.6 and Codex accelerated this project
+## Two Build Week Tracks
 
-This project was not produced by asking an AI to generate a theorem in one step.
+### Track 1 — Finite-prime escape and Cosmic completion
 
-Instead, GPT-5.6 and Codex were used as two complementary reasoning and implementation partners inside a verifiable development loop.
+The recorded demonstration begins with a finite set of known primes, forms its
+product `P`, chooses a coprime offset `u`, and proves that every prime divisor
+of `P + u` lies outside the original finite set.
 
-### GPT-5.6: mathematical review and research guidance
+The same construction is displayed through the Cosmic Formula completion:
+
+$$
+P(P+2u)+u^2=(P+u)^2
+$$
+
+The public example uses:
+
+$$
+P=2\cdot3\cdot5\cdot7=210,\qquad u=11
+$$
+
+and therefore:
+
+$$
+P+u=221=13\cdot17.
+$$
+
+Lean entry points:
+
+- [`FinitePrimeEscape.lean`](./FinitePrimeEscape.lean)
+- [`CosmicCompletion.lean`](./CosmicCompletion.lean)
+- [`Demo.lean`](./Demo.lean)
+
+### Track 2 — Post-video GN5 / exponent-five formalization
+
+The original video ended with the local observation that
+`GN(5,1,1) = 31` is not a perfect fifth power.
+
+After that recording, the same GPT-5.6 → Codex → Lean workflow continued on a
+second implementation track. The repository now contains a Lean-checked
+formalization whose public theorem surface includes:
+
+```lean
+goldenZeroSectorFactorExclusion
+goldenZeroSectorArithmeticExclusion
+flt5Target
+fermatFive_no_positive_solution
+```
+
+The encoded public statement is:
+
+$$
+x,y,z\in\mathbb N_{>0}\Longrightarrow x^5+y^5\ne z^5.
+$$
+
+The final descent uses the golden lift
+
+$$
+T(r,s)=(r^2+rs+s^2,s^2)
+$$
+
+to reconstruct the same invariant with a strictly smaller second-coordinate
+measure.
+
+Review and implementation entry points:
+
+- [PR #56 — signed golden zero-sector descent](https://github.com/Deskuma/dkmath/pull/56)
+- [`DkMath.FLT.Five.Main`](../FLT/Five/Main.lean)
+- [`SignedGoldenZeroSectorDescent.lean`](../FLT/Five/SignedGoldenZeroSectorDescent.lean)
+- [`SignedGoldenZeroSectorFinal.lean`](../FLT/Five/SignedGoldenZeroSectorFinal.lean)
+- [Axiom-surface inspection](../../DkMathTest/FLT/Five/CheckAxioms.lean)
+- [Final implementation report](../FLT/Five/docs/repo-flt5-cp-005-final.md)
+
+> [!NOTE]
+> This is presented as a Lean-checked repository result under the stated
+> theorem contract. It is now open for independent mathematical inspection,
+> dependency review, axiom-surface inspection, and build reproduction. This
+> page does not claim completed external peer review or established acceptance
+> by the mathematical community.
+
+## Watch the Project
+
+![Cosmic Formula animation](../../docs/hackathon/cosmic-formula-inversion-260715/visual/media/videos/cosmic_formula_scene/720p30/CosmicFormulaPrototype.gif)
+
+The first-track animation is also stored in the repository:
+
+▶️ **[Cosmic Formula animated learning prototype (MP4)](../../docs/hackathon/cosmic-formula-inversion-260715/visual/media/videos/cosmic_formula_scene/720p30/CosmicFormulaPrototype.mp4)**
+
+The final narrated Build Week video includes the post-recording exponent-five
+update and is exactly three minutes long.
+
+To find the public upload on YouTube, search for:
+
+```text
+DkMath A Lean-Checked Formalization of the Exponent-5 Case Open for Review
+```
+
+Devpost project page:
+
+- [DkMath — Verifiable AI Mathematical Research](https://devpost.com/software/dkmath-verifiable-ai-mathematical-research)
+
+## How GPT-5.6 and Codex Contributed
+
+### GPT-5.6
 
 GPT-5.6 was used to:
 
-- refine informal mathematical observations into explicit theorem targets;
-- review theorem strength, dependencies, and possible overclaims;
-- compare proposed structures with the existing DkMath architecture;
-- define concise implementation goals and stopping conditions for Codex;
-- review completed Lean reports and identify the next mathematical boundary;
-- prepare the public explanation, narration, and submission material.
+- turn informal observations into explicit theorem contracts;
+- inspect proof strength, dependencies, and possible overclaims;
+- connect new targets to the existing DkMath architecture;
+- define bounded implementation checkpoints and stopping rules;
+- review completed Lean reports and identify the next obstruction;
+- prepare the explanation, narration, and public documentation.
 
-The human researcher retained control of the mathematical direction and accepted only results that were successfully checked by Lean.
-
-### Codex: repository-scale investigation and implementation
+### Codex
 
 Codex was used to:
 
-- inspect a large existing Lean 4 repository and its development reports;
-- locate reusable definitions and theorems instead of rebuilding parallel APIs;
-- implement the finite-prime escape theorem and Cosmic completion bridge;
-- connect the result to the concrete GN5 clean channel;
-- run Lean builds and close proof failures;
-- create the Manim visualization and FFmpeg build pipeline;
-- build a reproducible Kokoro TTS narration pipeline;
-- produce the final synchronized, narrated, sub-three-minute promo video.
+- inspect a large existing Lean repository;
+- locate reusable definitions and theorem surfaces;
+- implement and refactor the finite-prime and FLT5 routes;
+- repair proof failures under Lean feedback;
+- record checkpoint reports and dependency decisions;
+- create the Manim, Kokoro TTS, subtitle, and FFmpeg pipelines;
+- assemble the final synchronized video artifacts.
 
-This significantly reduced the time normally spent on repository reconnaissance, API discovery, repetitive proof repair, media scripting, and command-line production work.
+### Human researcher
 
-### The verified result
+The human researcher selected the mathematical direction, evaluated the
+interpretation, controlled the research scope, and accepted only theorem
+surfaces checked by Lean.
 
-The workflow produced:
+## Reproduction
 
-- a general finite-prime escape theorem;
-- the Cosmic completion identity;
-- a fixed Lean-verified example at `221 = 13 × 17`;
-- a GN5 local obstruction proving that `GN(5,1,1)` is not a perfect fifth power;
-- a reproducible visual, subtitle, TTS, and FFmpeg publication pipeline.
+From the Lean workspace:
 
-Lean, not the AI systems, is the final authority for the accepted mathematical declarations.
+```bash
+cd lean/dk_math
+lake build DkMath.Hackathon.Demo
+lake build DkMath.FLT.Five.Main
+lake build DkMathTest.FLT.Five.CheckAxioms
+```
 
-### What this demonstrates
-
-The project demonstrates a practical future learning and research method:
-
-1. a human selects and understands the research question;
-2. GPT-5.6 helps refine, review, and communicate the mathematical structure;
-3. Codex investigates and implements across the real repository;
-4. Lean verifies the accepted theorem surface;
-5. the same AI-assisted workflow turns the verified result into reproducible educational material.
-
-The final narrated promo itself was completed through this same pipeline, from theorem implementation to visualization, speech synthesis, synchronization, and publication.
-
----
-
-detail see: [README](../../docs/hackathon/cosmic-formula-inversion-260715/README.md)
-
----
+For the complete development history, documentation map, verification policy,
+and publication artifacts, continue to the
+[full Build Week project record](../../docs/hackathon/cosmic-formula-inversion-260715/README.md).

--- a/lean/dk_math/DkMathTest/FLT/Five/CheckAxioms.lean
+++ b/lean/dk_math/DkMathTest/FLT/Five/CheckAxioms.lean
@@ -7,6 +7,16 @@ Authors: D. and Wise Wolf.
 import DkMath.FLT.Five
 import DkMath.FLT.Five.Standalone
 
+/-!
+# Axiom-surface audit for the exponent-five route
+
+This file is an inspection entry point rather than a proof module. The
+declarations are ordered by the proof route from GN5 identities through the
+five-adic and golden-order layers to the final public theorem. Run or inspect
+the `#print axioms` commands to verify the dependency surface.
+-/
+
+-- GN5 foundation.
 #print axioms DkMath.FLT.Five.add_pow_five_eq_add_mul_GN5
 #print axioms DkMath.FLT.Five.GN5_eq_homogeneous_cyclotomic
 #print axioms DkMath.FLT.Five.GN5_eq_gap_mul_add_five_mul_y_pow_four
@@ -16,13 +26,16 @@ import DkMath.FLT.Five.Standalone
 #print axioms DkMath.FLT.Five.body5_eq_fifth_power_of_fermat
 #print axioms DkMath.FLT.Five.padicValNat_lower_bound_d5
 #print axioms DkMath.FLT.Five.padicValNat_clean_body_upper_bound
+#print axioms DkMath.FLT.Five.padicValNat_clean_body_eq_one
 #print axioms DkMath.FLT.Five.Standalone.add_pow_five_eq_add_mul_GN5
 
+-- Clean-channel obstruction.
 #print axioms DkMath.FLT.Five.add_pow_five_sub_eq_mul_GN5
 #print axioms DkMath.FLT.Five.not_fifth_power_body_of_clean
 #print axioms DkMath.FLT.Five.counterexample_false_of_clean_GN5Channel_by_dvd
 #print axioms DkMath.FLT.Five.counterexample_false_of_clean_GN5Channel_by_padicValNat
 
+-- Five-adic routing.
 #print axioms DkMath.FLT.Five.coprime_gap_GN5_of_coprime_of_five_not_dvd
 #print axioms DkMath.FLT.Five.branchB_coprime_gap_GN5
 #print axioms DkMath.FLT.Five.fifth_power_factor_split
@@ -33,6 +46,7 @@ import DkMath.FLT.Five.Standalone
 #print axioms DkMath.FLT.Five.exists_branchB_fifthPowerNormalForm
 #print axioms DkMath.FLT.Five.branchB_false_of_fifthPowerCore
 
+-- Golden order.
 #print axioms DkMath.FLT.Five.GN5_eq_square_cross_form
 #print axioms DkMath.FLT.Five.square_cross_coordinate_change
 #print axioms DkMath.FLT.Five.GN5_eq_goldenNorm_squareLink
@@ -139,6 +153,7 @@ import DkMath.FLT.Five.Standalone
 #print axioms DkMath.FLT.Five.positiveFermat5Refuter_of_unitClasses_of_zeroArithmetic
 #print axioms DkMath.FLT.Five.flt5Target_of_unitClasses_of_zeroArithmetic
 
+-- Unit classification.
 #print axioms DkMath.FLT.Five.golden_phi_mul_inv
 #print axioms DkMath.FLT.Five.golden_inv_mul_phi
 #print axioms DkMath.FLT.Five.goldenUnit_descent
@@ -151,7 +166,7 @@ import DkMath.FLT.Five.Standalone
 #print axioms DkMath.FLT.Five.positiveFermat5Refuter_of_zeroArithmetic
 #print axioms DkMath.FLT.Five.flt5Target_of_zeroArithmetic
 
--- Certified zero-sector inversion and factorization.
+-- Zero-sector descent.
 #print axioms DkMath.FLT.Five.goldenZeroSectorCandidate_of_raw
 #print axioms DkMath.FLT.Five.goldenZeroSectorInversionPacket
 #print axioms DkMath.FLT.Five.GoldenZeroSectorInversionPacket.factor_product
@@ -162,8 +177,6 @@ import DkMath.FLT.Five.Standalone
 #print axioms DkMath.FLT.Five.goldenZeroSectorFactorPacket_of_inversion
 #print axioms DkMath.FLT.Five.nonempty_goldenZeroSectorFactorPacket
 #print axioms DkMath.FLT.Five.goldenZeroSectorFactorArithmeticExclusion_of_factorExclusion
-
--- Strict golden-lift descent and unconditional closure.
 #print axioms DkMath.FLT.Five.goldenZeroSectorLift_norm
 #print axioms DkMath.FLT.Five.GoldenZeroSectorDescentPacket.lift_relPrime_conj
 #print axioms DkMath.FLT.Five.five_dvd_norm_of_nonzero_goldenUnitSector
@@ -178,6 +191,8 @@ import DkMath.FLT.Five.Standalone
 #print axioms DkMath.FLT.Five.goldenZeroSectorDescentPacket_of_candidate
 #print axioms DkMath.FLT.Five.goldenZeroSectorCandidate_false
 #print axioms DkMath.FLT.Five.goldenZeroSectorFactorExclusion
+
+-- Public closure.
 #print axioms DkMath.FLT.Five.goldenZeroSectorArithmeticExclusion_of_factorExclusion
 #print axioms DkMath.FLT.Five.goldenZeroSectorArithmeticExclusion
 #print axioms DkMath.FLT.Five.flt5Target

--- a/lean/dk_math/DkMathTest/FLT/Five/CheckAxioms.lean
+++ b/lean/dk_math/DkMathTest/FLT/Five/CheckAxioms.lean
@@ -8,6 +8,9 @@ import DkMath.FLT.Five
 import DkMath.FLT.Five.Standalone
 
 #print axioms DkMath.FLT.Five.add_pow_five_eq_add_mul_GN5
+#print axioms DkMath.FLT.Five.GN5_eq_homogeneous_cyclotomic
+#print axioms DkMath.FLT.Five.GN5_eq_gap_mul_add_five_mul_y_pow_four
+#print axioms DkMath.FLT.Five.GN5_eq_g_pow_four_add_five_mul
 #print axioms DkMath.FLT.Five.GN5_one_one_not_fifth_power
 #print axioms DkMath.FLT.Five.CleanGN5Channel.not_sq_dvd_body
 #print axioms DkMath.FLT.Five.body5_eq_fifth_power_of_fermat
@@ -72,6 +75,11 @@ import DkMath.FLT.Five.Standalone
 
 #print axioms DkMath.FLT.Five.goldenConj_mul
 #print axioms DkMath.FLT.Five.goldenNorm_mul
+#print axioms DkMath.FLT.Five.golden_phi_sq
+#print axioms DkMath.FLT.Five.goldenConj_phi
+#print axioms DkMath.FLT.Five.goldenNorm_phi
+#print axioms DkMath.FLT.Five.goldenConj_ofInt
+#print axioms DkMath.FLT.Five.goldenNorm_ofInt
 #print axioms DkMath.FLT.Five.golden_tau_mul_conj
 #print axioms DkMath.FLT.Five.exists_goldenTau_factor_of_five_dvd
 #print axioms DkMath.FLT.Five.signedGoldenRamifierStrippedPacket_of_exceptional

--- a/lean/dk_math/docs/hackathon/cosmic-formula-inversion-260715/README.md
+++ b/lean/dk_math/docs/hackathon/cosmic-formula-inversion-260715/README.md
@@ -436,6 +436,34 @@ This project does not claim:
 The exponent-five statement exposed by the current Lean API is specifically the
 positive-natural theorem encoded in `DkMath.FLT.Five.Main`.
 
+## Acknowledgments
+
+At the time the video was produced and edited, the project had reached only a local obstruction based on GN5.
+
+After the video was published and the hackathon submission was complete, I still had a little energy left. I therefore decided to continue the implementation as a second phase, to see how far the GN5 perspective could actually take us when put into practice.
+
+What emerged from that continuation was a Lean formalization of the exponent-five case of Fermat’s Last Theorem.
+
+Several formalizations of the exponent-five case already exist. In this project, however, we proceeded directly from GN5 without consulting those implementations, following the route that arose from our own investigation. I made the decisions about the mathematical direction and about what was appropriate to publish.
+
+During the implementation, we encountered a difficult question: how could the relevant unit be identified and handled? The AI also struggled with this problem for a considerable time.
+
+The breakthrough was inspired by a comment left by a reader on one of my articles on note.
+
+“A unit is always present. However, its form changes with the space in which it appears.”
+
+I had previously explained this idea using the metaphor of a 🎗️“red ribbon.” That explanation aligned with the problem before us with surprising precision and became the key to overcoming the obstacle.
+
+Without that comment, I do not think we would have passed this particular barrier.
+
+A brief and seemingly modest comment led to an idea that helped us overcome one of the most difficult stages of the implementation. I would therefore like to record my gratitude here. Thank you very much.
+
+Independent external review of the Lean implementation begins from this point.
+
+The AI worked extraordinarily hard. Now it is time for human readers to work equally hard to understand what has been constructed.
+
+When the formal understanding certified by Lean and the mathematical understanding of human readers finally meet, I believe this work will become a genuine step toward the truth.
+
 ---
 
 ## Authors and License

--- a/lean/dk_math/docs/hackathon/cosmic-formula-inversion-260715/README.md
+++ b/lean/dk_math/docs/hackathon/cosmic-formula-inversion-260715/README.md
@@ -1,83 +1,117 @@
-# Hackathon: OpenAI Build Week - 260715 @ devpost
+# DkMath — Verifiable AI Mathematical Research
 
-Date: 2026/07/18  1:19
-Author: Deskuma (D.) and AI GPT@OpenAI (Wise Wolf)
+OpenAI Build Week Hackathon project record  
+Started: 2026-07-15  
+Authors: Deskuma (D.) and AI GPT@OpenAI (Wise Wolf)
 
-## DkMath — Cosmic Formula Inversion
+> [!IMPORTANT]
+> This repository records a human-directed, AI-assisted mathematical research
+> workflow. GPT-5.6 and Codex helped reason, investigate, implement, review, and
+> publish the work. Lean is the verification gate for the accepted theorem
+> declarations.
 
-A verifiable AI-assisted mathematical research project for the OpenAI Build Week Hackathon.
+## Project Status
 
-This project demonstrates a workflow in which:
+The Build Week project now has two connected tracks.
 
-1. a mathematical structure is proposed and refined through human–AI dialogue;
-2. Codex investigates and implements the structure inside an existing Lean 4 library;
-3. Lean verifies the resulting theorem surface;
-4. the verified mathematics is transformed into an accessible visual demonstration.
+```text
+Track 1 — recorded demonstration
+finite-prime escape
+→ Cosmic Formula completion
+→ fresh factors outside a finite prime universe
+→ Lean verification
+→ visual explanation
 
-The main theme is the transition from a finite universe of known prime factors to a provably new prime factor, expressed through the DkMath Cosmic Formula, finite-prime escape, and the new GN5 extension.
+Track 2 — post-video research continuation
+GN5 local obstruction
+→ signed exponent-five reduction
+→ golden-integer factorization
+→ unit-sector elimination
+→ strict golden-lift descent
+→ Lean-checked positive-natural theorem surface
+→ independent human review
+```
+
+### Public entry points
+
+| Entry | Purpose |
+|---|---|
+| [`DkMath/Hackathon`](../../../DkMath/Hackathon/README.md) | Compact Lean-facing project entrance |
+| [Devpost project](https://devpost.com/software/dkmath-verifiable-ai-mathematical-research) | Hackathon submission page and project updates |
+| [PR #56](https://github.com/Deskuma/dkmath/pull/56) | Complete second-track implementation history |
+| [`DkMath.FLT.Five.Main`](../../../DkMath/FLT/Five/Main.lean) | Final exponent-five theorem surface |
+| [Axiom-surface inspection](../../../DkMathTest/FLT/Five/CheckAxioms.lean) | Explicit `#print axioms` audit entry point |
+| [Final FLT5 implementation report](../../../DkMath/FLT/Five/docs/repo-flt5-cp-005-final.md) | Compact completion report |
+
+## Final Video
+
+The final narrated video combines the original finite-prime demonstration with
+a post-recording update on the exponent-five formalization. Its final running
+time is exactly three minutes.
+
+A direct YouTube link is intentionally not embedded here. Search YouTube for:
+
+```text
+DkMath A Lean-Checked Formalization of the Exponent-5 Case Open for Review
+```
+
+The repository also contains the original animation and the reproducible media
+pipeline.
+
+- [Cosmic Formula prototype animation](./visual/media/videos/cosmic_formula_scene/720p30/CosmicFormulaPrototype.mp4)
+- [Final submission pipeline](./submission/README.md)
+- [Post-video appendix pipeline](./submission/dkmath-flt5-video-appendix/README.md)
 
 ---
 
-## Project Goal
+## Track 1 — Cosmic Formula Inversion Demonstration
 
-The first public demonstration follows one short mathematical path:
+### Goal
+
+The first public demonstration follows a short, exact mathematical path:
 
 ```text
 finite prime universe
 → product of known primes
 → coprime offset
 → completed square
-→ factorization outside the known universe
+→ factorization outside the original universe
 → Lean verification
 → visual explanation
 ```
 
-The project is not intended to create an isolated theorem file.
+The purpose was not to create an isolated theorem file. The goal was to show
+that an AI coding agent can inspect a large formal library, reuse existing
+abstractions, isolate missing bridges, implement only the necessary layer, and
+report the exact boundary reached.
 
-Its purpose is to expose a clear, verifiable path through the existing DkMath library and show how an AI coding agent can:
-
-- inspect a large formal mathematics codebase;
-- reuse existing abstractions;
-- isolate genuinely missing lemmas;
-- implement only the necessary bridge layer;
-- verify the result with Lean;
-- report the exact remaining mathematical obstruction.
-
----
-
-## Core Mathematical Contract
+### Mathematical contract
 
 Let `S` be a finite set of prime numbers and define:
 
 $$
-P=\prod_{p\in S}p
+P=\prod_{p\in S}p.
 $$
 
 Choose a positive integer `u` satisfying:
 
 $$
-\gcd(P,u)=1
+\gcd(P,u)=1.
 $$
 
-Assume:
+If a prime `q` divides `P+u`, then it cannot belong to the original finite set:
 
 $$
-1<P+u
+q\mid P+u\Longrightarrow q\notin S.
 $$
 
-If a prime `q` divides `P + u`, then `q` cannot belong to the original finite prime set:
+The Cosmic Formula completion is:
 
 $$
-q\mid P+u\Longrightarrow q\notin S
+P(P+2u)+u^2=(P+u)^2.
 $$
 
-The geometric completion identity is:
-
-$$
-P(P+2u)+u^2=(P+u)^2
-$$
-
-DkMath interprets this as:
+DkMath reads this as:
 
 ```text
 Big  = (P + u)²
@@ -88,470 +122,326 @@ Gap  = u²
 with:
 
 $$
-\mathrm{Big}=\mathrm{Body}+\mathrm{Gap}
+\mathrm{Big}=\mathrm{Body}+\mathrm{Gap}.
 $$
 
-The prime factors of `P + u` therefore appear on the completed boundary, while the Body is generated from the finite known-prime universe.
+### Demonstration example
 
----
-
-## Demonstration Example
-
-The initial demonstration uses:
+The recorded example uses:
 
 $$
-S=\{2,3,5,7\}
-$$
-
-$$
-P=2\cdot3\cdot5\cdot7=210
-$$
-
-$$
-u=11
+S=\{2,3,5,7\},\qquad P=210,\qquad u=11.
 $$
 
 Then:
 
 $$
-P+u=221=13\cdot17
+P+u=221=13\cdot17.
 $$
 
-Both `13` and `17` lie outside the original set `S`.
-
-The Cosmic Formula completion is:
+Both `13` and `17` lie outside the original finite set. The completion is:
 
 $$
-210\cdot232+11^2=221^2
+210\cdot232+11^2=221^2.
 $$
 
-or numerically:
+Lean modules:
+
+- [`FinitePrimeEscape.lean`](../../../DkMath/Hackathon/FinitePrimeEscape.lean)
+- [`CosmicCompletion.lean`](../../../DkMath/Hackathon/CosmicCompletion.lean)
+- [`Demo.lean`](../../../DkMath/Hackathon/Demo.lean)
+
+---
+
+## Track 2 — Post-Video GN5 / Exponent-Five Formalization
+
+### How the second track began
+
+The original video reached the concrete fifth-degree observation:
 
 $$
-48720+121=48841
+GN(5,1,1)=31,
 $$
 
-This single example will be shared by:
+and showed in Lean that this value is not a perfect fifth power. At recording
+time, that was deliberately presented as a local GN5 channel rather than a
+completed general theorem.
 
-- the Lean theorem demonstration;
-- the Manim animation;
-- the submission video;
-- the project documentation;
-- the final interactive or scripted demo.
+After the recording, the same research loop continued:
 
-Using one common example prevents the formal proof, visual explanation, and submission narrative from drifting into separate mathematical stories.
+```text
+human direction
+→ GPT-5.6 mathematical review and checkpoint design
+→ Codex repository investigation and Lean implementation
+→ Lean feedback and proof repair
+→ final theorem-surface and axiom audit
+```
+
+The implementation history is preserved in
+[PR #56 — `FLT/Five: close the signed golden zero-sector descent`](https://github.com/Deskuma/dkmath/pull/56).
+
+### Lean-checked theorem surface
+
+The final public declarations include:
+
+```lean
+goldenZeroSectorFactorExclusion
+goldenZeroSectorArithmeticExclusion
+flt5Target
+fermatFive_no_positive_solution
+```
+
+The ordinary-argument theorem has the scope:
+
+$$
+x,y,z\in\mathbb N_{>0}\Longrightarrow x^5+y^5\ne z^5.
+$$
+
+The public entry point is
+[`DkMath.FLT.Five.Main`](../../../DkMath/FLT/Five/Main.lean).
+
+### Descent structure
+
+The final stage uses the golden lift:
+
+$$
+T(r,s)=(r^2+rs+s^2,s^2).
+$$
+
+Its norm reconstructs the required fifth-degree invariant, while the returned
+packet has a strictly smaller second-coordinate absolute measure. Strong
+induction then closes the infinite-descent contradiction.
+
+Key source files:
+
+- [`SignedGoldenZeroSectorInversion.lean`](../../../DkMath/FLT/Five/SignedGoldenZeroSectorInversion.lean)
+- [`SignedGoldenZeroSectorFactorization.lean`](../../../DkMath/FLT/Five/SignedGoldenZeroSectorFactorization.lean)
+- [`SignedGoldenZeroSectorDescent.lean`](../../../DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean)
+- [`SignedGoldenZeroSectorFinal.lean`](../../../DkMath/FLT/Five/SignedGoldenZeroSectorFinal.lean)
+- [`Main.lean`](../../../DkMath/FLT/Five/Main.lean)
+
+### Review boundary
+
+> [!NOTE]
+> The repository currently presents this as a Lean-checked implementation under
+> its explicit theorem contract. The next stage is independent human work:
+> mathematical inspection, dependency review, axiom-surface inspection,
+> reproduction, simplification, and correction where necessary.
+>
+> This project record does not claim completed external peer review or
+> established acceptance by the mathematical community.
+
+Suggested review path:
+
+```text
+PR #56 history
+→ Main.lean theorem signatures
+→ SignedGoldenZeroSectorFinal.lean
+→ SignedGoldenZeroSectorDescent.lean
+→ CheckAxioms.lean
+→ independent build reproduction
+```
 
 ---
 
 ## Why This Matters
 
-The elementary prime-factor argument is not the final research goal.
+The mathematical artifacts are important, but the central hackathon result is
+the complete verifiable workflow.
 
-It is the smallest verifiable example of a broader DkMath program:
+The project demonstrates that one compact human–AI loop can:
 
-```text
-finite arithmetic world
-→ boundary completion
-→ new factor channel
-→ normalized projection
-→ bounded inverse representation
-→ reconstruction of an integer-scale structure
+1. begin with an educationally understandable example;
+2. expose it as exact Lean declarations;
+3. let GPT-5.6 review theorem strength and research direction;
+4. let Codex inspect and modify a real repository at scale;
+5. use Lean errors as formal feedback rather than rhetorical confidence;
+6. preserve implementation history in checkpoints and pull requests;
+7. turn the verified material into visual, narrated, reproducible media;
+8. leave a public surface for later human review.
+
+The code, reports, PR history, and publication pipeline are all part of the
+submission—not merely the final video.
+
+## Roles in the Workflow
+
+### Human researcher
+
+The human researcher:
+
+- selected the mathematical direction;
+- supplied the original interpretations and research questions;
+- decided which claims were meaningful;
+- controlled scope and stopping rules;
+- accepted only theorem surfaces checked by Lean;
+- chose how strongly the result should be presented publicly.
+
+### GPT-5.6
+
+GPT-5.6 was used to:
+
+- refine informal observations into theorem contracts;
+- review theorem strength and possible overclaims;
+- compare proposed structures with existing DkMath architecture;
+- design bounded Codex checkpoints;
+- inspect completed reports and identify the next obstruction;
+- translate the result between DkMath language and standard mathematics;
+- prepare narration, explanatory structure, and publication text.
+
+### Codex
+
+Codex was used to:
+
+- inspect a large Lean 4 codebase and its historical reports;
+- locate reusable definitions rather than create parallel APIs;
+- implement, refactor, and connect the proof tower;
+- repair proof failures from Lean diagnostics;
+- produce checkpoint reports and implementation maps;
+- create Manim, Kokoro TTS, subtitle, and FFmpeg tooling;
+- assemble the final three-minute video.
+
+### Lean
+
+Lean checks the theorem terms accepted by the project. Numerical experiments,
+AI explanations, visualizations, and prose remain supplementary and do not
+replace the formal verification gate.
+
+---
+
+## Reproduction
+
+From the Lean workspace:
+
+```bash
+cd lean/dk_math
+lake build DkMath.Hackathon.Demo
+lake build DkMath.FLT.Five.Main
+lake build DkMathTest.FLT.Five.CheckAxioms
 ```
 
-The larger project studies how apparently unbounded arithmetic structures can be projected into bounded interval representations and later reconstructed through formally verified inverse maps.
+Reviewers may also import the compact aggregate:
 
-The hackathon version deliberately begins with a theorem that is:
-
-- finite;
-- exact;
-- visually understandable;
-- inexpensive to verify;
-- connected to deeper existing DkMath infrastructure.
-
----
-
-## Repository Branch
-
-```text
-repository: Deskuma/dkmath
-base branch: nightly
-working branch: hackathon/cosmic-formula-inversion
+```lean
+import DkMath.FLT.Five
 ```
 
----
-
-## Lean Module Layout
-
-The hackathon-facing Lean surface is intentionally thin.
-
-```text
-DkMath/Hackathon/
-├── FinitePrimeEscape.lean
-├── CosmicCompletion.lean
-└── Demo.lean
-```
-
-### `FinitePrimeEscape.lean`
-
-Responsibilities:
-
-- finite sets of known primes;
-- their product `P`;
-- coprimality with the offset `u`;
-- existence of a prime divisor of `P + u`;
-- proof that such a divisor is outside the original finite set.
-
-### `CosmicCompletion.lean`
-
-Responsibilities:
-
-- the identity
-
-$$
-P(P+2u)+u^2=(P+u)^2
-$$
-
-- connection to existing Big / Body / Gap APIs;
-- reusable wrappers around existing DkMath Cosmic Formula theorems;
-- no duplicate parallel theory.
-
-### `Demo.lean`
-
-Responsibilities:
-
-- the concrete example `P = 210`, `u = 11`;
-- factorization `221 = 13 × 17`;
-- final public theorem surface;
-- a compact import path for the recorded demonstration.
-
-These modules must depend on existing DkMath infrastructure.
-
-Existing DkMath modules must never import the hackathon facade.
+The axiom inspection file enumerates the main route using `#print axioms` and
+ends with the final theorem surface.
 
 ---
 
-## Documentation Layout
-
-[docs/hackathon/cosmic-formula-inversion-260715/](./)
-
-```text
-docs/hackathon/cosmic-formula-inversion-260715/
-├── README.md
-├── PROJECT.md
-├── ROADMAP.md
-├── MATHEMATICAL_CONTRACT.md
-├── ARCHITECTURE.md
-├── EXISTING_DKMATH_MAP.md
-├── VISUAL_STORYBOARD.md
-├── DEMO_CONTRACT.md
-├── CODEX_PLAN.md
-├── CHECKPOINTS.md
-├── DECISIONS.md
-├── GLOSSARY.md
-└── RISKS_AND_STOPPING_RULES.md
-```
-
-The documentation is part of the project deliverable.
-
-It records not only the final theorem, but also:
-
-- why the theorem surface was selected;
-- how the existing library was audited;
-- which definitions were reused;
-- which missing lemmas were discovered;
-- where Codex was instructed to stop;
-- how the verified theorem was converted into a visual explanation.
-
----
-
-## Required Reading Order for Codex
-
-Before modifying source code, Codex must read the project documents in this order:
-
-1. [README.md](./README.md)
-2. [PROJECT.md](./PROJECT.md)
-3. [MATHEMATICAL_CONTRACT.md](./MATHEMATICAL_CONTRACT.md)
-4. [ROADMAP.md](./ROADMAP.md)
-5. [ARCHITECTURE.md](./ARCHITECTURE.md)
-6. [GLOSSARY.md](./GLOSSARY.md)
-7. [DECISIONS.md](./DECISIONS.md)
-8. [RISKS_AND_STOPPING_RULES.md](./RISKS_AND_STOPPING_RULES.md)
-9. [EXISTING_DKMATH_MAP.md](./EXISTING_DKMATH_MAP.md)
-10. [VISUAL_STORYBOARD.md](./VISUAL_STORYBOARD.md)
-11. [DEMO_CONTRACT.md](./DEMO_CONTRACT.md)
-12. [CHECKPOINTS.md](./CHECKPOINTS.md)
-13. [CODEX_PLAN.md](./CODEX_PLAN.md)
-14. the current checkpoint instruction
-
-This order should remain stable across sessions.
-
-The stable prefix exists to preserve a consistent project interpretation and reduce repeated repository exploration.
-
----
-
-## Tracking Anchor Files
-
-UUID-named empty files inside the hackathon documentation directory are intentional tracking anchors.
-
-Example form:
-
-```text
-6a54173a-e5f8-83ee-9983-6932a7be858c
-```
-
-They connect repository checkpoints to their originating research conversation.
-
-Rules:
-
-- do not delete them;
-- do not rename them;
-- do not add content to them;
-- do not inspect them after confirming that they are empty;
-- do not treat them as implementation inputs.
-
-Their filenames are metadata. Their contents are intentionally empty.
-
----
-
-## Codex Operating Principles
-
-Codex must act as a repository-aware mathematical implementation agent, not as a code transcription tool.
-
-### Required behavior
-
-- inspect existing DkMath APIs before defining new ones;
-- prefer theorem wrappers and bridge lemmas over parallel abstractions;
-- preserve existing dependency directions;
-- verify every implementation checkpoint with Lean;
-- distinguish mathematical obstruction from API inconvenience;
-- stop at the first genuine missing invariant;
-- record exact theorem names and file locations;
-- report what was proved and what remains unproved.
-
-### Prohibited behavior
-
-- do not expand into unrelated DkMath research branches;
-- do not continue into Collatz, FLT, RH, ABC, or Erdős problems unless a direct reusable API is required;
-- do not create a second Big / Body / Gap hierarchy;
-- do not create new prime-factor terminology when an existing predicate is sufficient;
-- do not claim cryptographic security;
-- do not claim a new prime-number theorem;
-- do not infer an infinite theorem from a finite construction;
-- do not replace a formal proof obligation with numerical testing;
-- do not continue beyond the checkpoint stopping rule.
-
----
-
-## Terminology Boundary
-
-The project distinguishes several related terms.
-
-### Fresh prime factor
-
-A prime divisor of `P + u` that is not contained in the original finite prime set.
-
-This is the preferred term for the initial demonstration.
-
-### Primitive prime divisor
-
-A sequence-relative concept stating that a prime appears at one stage and not at specified earlier stages.
-
-This stronger term must not be used unless the theorem actually includes the required sequence-relative hypotheses.
-
-### Finite prime universe
-
-The finite arithmetic world generated by the selected prime set `S`, its product `P`, and the associated residue information.
-
-This is project terminology, not a replacement for standard algebraic definitions.
-
-### Inverse projection
-
-A later project phase in which unbounded arithmetic data is normalized into a bounded interval representation and reconstructed through a verified inverse or uniqueness theorem.
-
-The initial finite-prime theorem is an entry point to this phase, not the entire inverse-projection result.
-
----
-
-## Development Roadmap
-
-The intended phase structure is:
-
-```text
-Phase 0 — Project documentation and repository scaffold
-Phase 1 — Existing DkMath API audit
-Phase 2 — Finite prime escape theorem
-Phase 3 — Cosmic Formula completion bridge
-Phase 4 — Inverse projection surface
-Phase 5 — DkReal interval and reconstruction bridge
-Phase 6 — Manim visual implementation
-Phase 7 — Unified Lean and visual demo
-Phase 8 — Submission packaging
-```
-
-Each phase must have:
-
-- a precise theorem or artifact target;
-- an explicit file boundary;
-- a completion condition;
-- a stopping condition;
-- a report identifying the next genuine obstruction.
-
----
-
-## Visual Demonstration
-
-The first animation should remain under approximately sixty seconds.
-
-Planned sequence:
-
-```text
-1. Display the finite prime set {2, 3, 5, 7}.
-2. Combine the primes into P = 210.
-3. Construct the rectangular Body P(P + 2u).
-4. Display the missing square Gap u².
-5. Insert the Gap and complete the square (P + u)².
-6. Reveal the completed side length P + u = 221.
-7. Factor 221 into 13 × 17.
-8. Highlight that 13 and 17 are outside the original prime set.
-9. Show the corresponding Lean theorem and successful verification.
-```
-
-The animation explains the structure.
-
-Lean establishes the theorem.
-
-Neither layer substitutes for the other.
-
----
-
-## Supporting Research Footage
-
-The project may include short recorded footage from the DkMath Collatz formalization branch.
-
-That footage demonstrates the same development workflow at a much larger scale:
-
-```text
-repository audit
-→ theorem design
-→ Lean implementation
-→ error correction
-→ verification
-→ isolation of a genuine mathematical obstruction
-```
-
-The Collatz work is supporting evidence of the workflow.
-
-It is not the main theorem of this hackathon submission and no Collatz convergence claim is made.
-
----
-
-## Current Status
-
-The hackathon implementation and submission package are complete.
-
-Accepted Lean modules:
-
-```text
-DkMath/Hackathon/FinitePrimeEscape.lean
-DkMath/Hackathon/CosmicCompletion.lean
-DkMath/Hackathon/Demo.lean
-```
-
-Final submission package:
-
-```text
-submission/output/DkMathCosmicPromoFinal.mp4
-submission/README.md
-submission/narration.srt
-submission/build_submission.sh
-```
-
-Formal MVP, visual prototype, promo integration, and submission packaging have
-all passed their accepted checkpoints. Only external human publication tasks
-remain: optional narration and authentic footage, upload, and platform form
-completion. See `FINAL_HANDOFF.md` for the final artifact provenance, commands,
-checksums, and the exact future inverse-projection resume point.
-
----
-
-## First Codex Audit Session
-
-The first Codex session is investigation-only.
-
-Its target is:
-
-```text
-Read the complete hackathon documentation in the prescribed order.
-
-Do not edit Lean source files.
-
-Audit the existing DkMath repository for reusable definitions and theorems
-required by the mathematical contract.
-
-Identify:
-- APIs reusable without modification;
-- theorems requiring thin wrappers;
-- genuinely missing lemmas;
-- dangerous dependency directions;
-- the smallest viable implementation surface.
-
-Propose updates to EXISTING_DKMATH_MAP.md.
-
-Stop after producing the audit report.
-```
-
-The implementation checkpoint will be written only after this report has been reviewed.
+## Documentation Map
+
+The documentation is part of the deliverable. It records not only the accepted
+result, but how the project was scoped, audited, implemented, stopped, resumed,
+and published.
+
+### Core project documents
+
+1. [PROJECT.md](./PROJECT.md)
+2. [MATHEMATICAL_CONTRACT.md](./MATHEMATICAL_CONTRACT.md)
+3. [ROADMAP.md](./ROADMAP.md)
+4. [ARCHITECTURE.md](./ARCHITECTURE.md)
+5. [GLOSSARY.md](./GLOSSARY.md)
+6. [DECISIONS.md](./DECISIONS.md)
+7. [RISKS_AND_STOPPING_RULES.md](./RISKS_AND_STOPPING_RULES.md)
+8. [EXISTING_DKMATH_MAP.md](./EXISTING_DKMATH_MAP.md)
+9. [VISUAL_STORYBOARD.md](./VISUAL_STORYBOARD.md)
+10. [DEMO_CONTRACT.md](./DEMO_CONTRACT.md)
+11. [CHECKPOINTS.md](./CHECKPOINTS.md)
+12. [CODEX_PLAN.md](./CODEX_PLAN.md)
+13. [FINAL_HANDOFF.md](./FINAL_HANDOFF.md)
+
+### Publication and media
+
+- [Submission package](./submission/README.md)
+- [Post-video FLT5 appendix](./submission/dkmath-flt5-video-appendix/README.md)
+- [Visual implementation](./visual/README.md)
+- [TTS pipeline](./tts/README.md)
+
+### FLT5 implementation record
+
+- [Implementation plan](../../../DkMath/FLT/Five/docs/FLT5_IMPLEMENTS_PLAN.md)
+- [Checkpoint summary](../../../DkMath/FLT/Five/docs/flt5-cp-001-to-cp-004-summary.md)
+- [Final report](../../../DkMath/FLT/Five/docs/repo-flt5-cp-005-final.md)
+- [PR #56](https://github.com/Deskuma/dkmath/pull/56)
 
 ---
 
 ## Verification Policy
 
-Every implementation checkpoint must record:
+Every accepted implementation checkpoint records, where applicable:
 
 ```text
 checkpoint identifier
 goal
 model and reasoning level
-elapsed time
-credits consumed
 files changed
-definitions added
-theorems added
+definitions and theorems added
 build targets
-no-sorry status
-git diff status
+formal verification status
 genuine obstruction
 next permitted action
 session identifier
 ```
 
-Lean build success is the verification gate for formal claims.
+The project separates four kinds of evidence:
 
-Numerical examples and visual output are supplementary evidence only.
+```text
+Lean theorem declarations     formal verification surface
+CI and reproduction commands  build evidence
+numerical experiments          exploratory evidence
+visual and written material    explanatory evidence
+```
 
----
+These layers support one another but are not interchangeable.
 
-## Non-Goals
+## Terminology Boundary
 
-The first hackathon milestone does not claim:
+### Fresh prime factor
+
+A prime divisor of `P+u` that is not contained in the original finite prime set.
+This is the preferred term for the first demonstration.
+
+### Finite prime universe
+
+The finite arithmetic world generated by `S`, its product `P`, and associated
+residue information. This is DkMath project terminology, not a replacement for
+standard algebraic definitions.
+
+### Lean-checked formalization
+
+A collection of declarations accepted by Lean under the imported environment
+and encoded assumptions. It does not by itself mean that external mathematical
+review has been completed.
+
+### Independent review
+
+Human inspection of the mathematical reductions, definitions, dependencies,
+axiom surface, reproducibility, exposition, and potential corrections.
+
+## Non-Goals and Scope Limits
+
+This project does not claim:
 
 - a proof of the Collatz conjecture;
-- a new proof of the infinitude of primes;
-- a new primitive-prime-divisor theorem;
-- a general theory of aperiodic tilings;
+- a new general prime-number theorem;
+- a new general primitive-prime-divisor theorem;
+- a solution of general-exponent Fermat's Last Theorem;
+- completed external peer review of the exponent-five implementation;
 - cryptographic security;
-- a complete formalization of Euclidean area;
-- a complete DkReal inversion theorem;
-- a solution to any currently open mathematical problem.
+- a complete DkReal inversion theory;
+- that AI-generated prose is mathematical evidence.
 
-The project demonstrates a verifiable research workflow and a reusable structural bridge inside DkMath.
+The exponent-five statement exposed by the current Lean API is specifically the
+positive-natural theorem encoded in `DkMath.FLT.Five.Main`.
 
 ---
 
-## Authors
+## Authors and License
 
 D. and Wise Wolf
 
-The Lean source code is released under the MIT license used by the DkMath project.
-
-The project documentation records a human–AI collaborative mathematical research process.
+The Lean source code is released under the MIT license used by the DkMath
+project. The documentation records a human–AI collaborative mathematical
+research process and should be read together with the checked source.


### PR DESCRIPTION
## Summary

This PR prepares the GN5 / FLT5 hackathon work for promotion into `develop`.

It:

- rewrites the two hackathon README entrypoints as a two-track project record:
  - finite-prime escape and Cosmic completion;
  - the post-video continuation from GN5 into the positive-natural exponent-five formalization;
- strengthens mathematician-facing module documentation and declaration docstrings across the `DkMath.FLT.Five` proof tower;
- adds canonical explanatory API around GN5, the golden quadratic order, the clean-channel valuation, and the strict zero-sector descent;
- expands `DkMathTest.FLT.Five.CheckAxioms` into a readable axiom-surface audit entry point;
- records the cp-006 documentation pass and its final polish;
- adds a human acknowledgment describing the post-video second phase, the role of AI, and the reader comment that inspired the unit interpretation.

## Mathematical scope

The public endpoint remains exactly the positive-natural exponent-five statement:

```lean
DkMath.FLT.Five.flt5Target
DkMath.FLT.Five.fermatFive_no_positive_solution
```

This PR does not claim:

- a general-exponent Fermat theorem;
- a signed nonzero-integer wrapper;
- completed external peer review or mathematical-community acceptance.

## Main review entry points

```text
lean/dk_math/DkMath/Hackathon/README.md
lean/dk_math/docs/hackathon/cosmic-formula-inversion-260715/README.md
lean/dk_math/DkMath/FLT/Five.lean
lean/dk_math/DkMath/FLT/Five/GN5.lean
lean/dk_math/DkMath/FLT/Five/GoldenOrder.lean
lean/dk_math/DkMath/FLT/Five/SignedGoldenZeroSectorDescent.lean
lean/dk_math/DkMath/FLT/Five/Main.lean
lean/dk_math/DkMathTest/FLT/Five/CheckAxioms.lean
lean/dk_math/DkMath/FLT/Five/docs/repo-flt5-cp-006-docstring.md
```

## Notable explanatory additions

- GN5 identified with the standard homogeneous fifth cyclotomic factor;
- reusable gap and mod-five decompositions;
- exact clean-channel valuation-one theorem;
- explicit documentation of `GoldenInt` as the coordinate order `ℤ[φ]` with `φ² = φ + 1`;
- theorem-level explanation of the lift, recursive packet, strictly decreasing `|s|` measure, and non-circular strong-induction closure;
- a categorized `#print axioms` audit from GN5 foundations to the final public theorem.

## Verification recorded by cp-006

```bash
cd lean/dk_math
lake build DkMath.FLT.Five
lake build DkMathTest.FLT.Five.CheckAxioms
```

The cp-006 final pass also removes the observed `unnecessarySeqFocus` and `unnecessarySimpa` warnings without suppressing the linters.

## Base-branch note

At PR creation time, `develop` contains three newer commits under `docs/BookOfMagic`. Those paths do not overlap the files changed here.