### PR TITLE
Integrate the ABC–GN deterministic spine and explicit K-epsilon budget bridge

### DIFF
--- a/lean/dk_math/DkMath/ABC/GNExceptionalSplit.lean
+++ b/lean/dk_math/DkMath/ABC/GNExceptionalSplit.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNValuationSplit
+import DkMath.NumberTheory.Gcd.GN
+
+#print "file: DkMath.ABC.GNExceptionalSplit"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# Exponent-exceptional and non-exceptional GN channels
+
+For an ABC triple, every common divisor of the boundary `T.a` and the kernel
+`GN n T.a T.b` divides the exponent `n`.  Thus a channel `q ∤ n` occurring on
+the GN side cannot also occur on the boundary side.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/-- The common boundary–GN divisor is confined to the exponent. -/
+theorem Triple.gcd_boundary_GN_dvd_exp
+    (T : Triple) {n : ℕ} (hn : 1 ≤ n) (ha : 0 < T.a) :
+    Nat.gcd T.a (GN n T.a T.b) ∣ n := by
+  have hb_lt : T.b < T.a + T.b := by omega
+  have hcop : Nat.Coprime (T.a + T.b) T.b :=
+    (Nat.coprime_add_self_left).2 T.hcop
+  simpa [Nat.add_sub_cancel_left] using
+    (DkMath.NumberTheory.Gcd.gcd_gap_GN_dvd_exp
+      (p := n) (z := T.a + T.b) (y := T.b) hn hb_lt hcop)
+
+/-- Every common divisor of the boundary and GN kernel divides the exponent. -/
+theorem Triple.dvd_exp_of_dvd_boundary_of_dvd_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a)
+    (hq_boundary : q ∣ T.a) (hq_GN : q ∣ GN n T.a T.b) :
+    q ∣ n := by
+  exact dvd_trans (Nat.dvd_gcd hq_boundary hq_GN)
+    (T.gcd_boundary_GN_dvd_exp hn ha)
+
+/--
+A non-exceptional GN channel `q ∤ n` is absent from the ABC boundary.
+
+No primality assumption is needed: this holds for every divisor occurring on
+the GN side.
+-/
+theorem Triple.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a)
+    (hq_exp : ¬ q ∣ n) (hq_GN : q ∣ GN n T.a T.b) :
+    ¬ q ∣ T.a := by
+  intro hq_boundary
+  exact hq_exp (T.dvd_exp_of_dvd_boundary_of_dvd_GN
+    hn ha hq_boundary hq_GN)
+
+/--
+On a non-exceptional prime channel present in GN, the full power-difference
+valuation is concentrated on the GN kernel.
+-/
+theorem Triple.padic_powerDiff_eq_GN_of_not_dvd_exp_of_dvd_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hq : Nat.Prime q) (hq_exp : ¬ q ∣ n)
+    (hq_GN : q ∣ GN n T.a T.b) :
+    padicValNat q (T.c ^ n - T.b ^ n) =
+      padicValNat q (GN n T.a T.b) := by
+  have hq_boundary : ¬ q ∣ T.a :=
+    T.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+      (Nat.le_trans (by decide) hn) ha hq_exp hq_GN
+  exact T.padic_powerDiff_eq_GN_of_not_dvd_boundary hn ha hb hq hq_boundary
+
+/-- Coprimality with the exponent removes all boundary–GN overlap. -/
+theorem Triple.coprime_boundary_GN_of_coprime_exp
+    (T : Triple) {n : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a) (hcop_exp : Nat.Coprime T.a n) :
+    Nat.Coprime T.a (GN n T.a T.b) := by
+  exact
+    DkMath.NumberTheory.Gcd.coprime_boundary_GN_of_coprime_add_of_coprime_exp
+      hn ha ((Nat.coprime_add_self_left).2 T.hcop) hcop_exp
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNFinalBudgetBridge.lean
+++ b/lean/dk_math/DkMath/ABC/GNFinalBudgetBridge.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNSupportReturn
+
+#print "file: DkMath.ABC.GNFinalBudgetBridge"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# Two-budget final ABC bridge
+
+This module combines a prime-support growth budget with an independent
+valuation-multiplicity budget.  It proves an explicit pointwise ABC bound and
+packages the genuinely uniform hypotheses needed for a positive-triple
+global theorem.
+-/
+
+namespace DkMath.ABC
+
+/-- Affine upper budget for the full GN valuation excess. -/
+def GNValuationExcessBudgetAffine
+    (T : Triple) (n : ℕ) (τ D : ℝ) : Prop :=
+  GNValuationExcess n T.a T.b ≤
+    τ * Real.log (rad (T.a * T.b * T.c) : ℝ) + D
+
+/-- Affine upper budget for exponent-exceptional valuation excess. -/
+def GNExceptionalExcessBudgetAffine
+    (T : Triple) (n : ℕ) (τ D : ℝ) : Prop :=
+  GNExceptionalValuationExcess n T.a T.b ≤
+    τ * Real.log (rad (T.a * T.b * T.c) : ℝ) + D
+
+/-- Affine upper budget for non-exceptional valuation excess. -/
+def GNNonExceptionalExcessBudgetAffine
+    (T : Triple) (n : ℕ) (τ D : ℝ) : Prop :=
+  GNNonExceptionalValuationExcess n T.a T.b ≤
+    τ * Real.log (rad (T.a * T.b * T.c) : ℝ) + D
+
+/-- Exceptional and non-exceptional multiplicity budgets add exactly. -/
+theorem GNValuationExcessBudgetAffine.of_split
+    {T : Triple} {n : ℕ} {τe De τn Dn : ℝ}
+    (he : GNExceptionalExcessBudgetAffine T n τe De)
+    (hn : GNNonExceptionalExcessBudgetAffine T n τn Dn) :
+    GNValuationExcessBudgetAffine T n (τe + τn) (De + Dn) := by
+  have hsplit :=
+    GNValuationExcess_eq_exceptional_add_nonExceptional n T.a T.b
+  dsimp [GNExceptionalExcessBudgetAffine] at he
+  dsimp [GNNonExceptionalExcessBudgetAffine] at hn
+  dsimp [GNValuationExcessBudgetAffine]
+  nlinarith
+
+/-- Support and multiplicity budgets give a direct logarithmic height bound. -/
+theorem Triple.log_c_mul_pred_le_of_support_and_excessBudget
+    (T : Triple) {n : ℕ} {σ Cs τ Ce : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hsupport : GNSupportBudgetAffine T n σ Cs)
+    (hexcess : GNValuationExcessBudgetAffine T n τ Ce) :
+    (((n - 1 : ℕ) : ℝ) * Real.log (T.c : ℝ)) ≤
+      (σ + τ) * Real.log (rad (T.a * T.b * T.c) : ℝ) +
+        (Cs + Ce) := by
+  have hreturn := T.log_c_mul_pred_le_log_GN hn ha hb
+  have hidentity := T.log_GN_eq_log_rad_add_GNValuationExcess hn ha hb
+  change Real.log (rad (DkMath.CosmicFormulaBinom.GN n T.a T.b) : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) + Cs at hsupport
+  dsimp [GNValuationExcessBudgetAffine] at hexcess
+  nlinarith
+
+/-- Lifted support growth plus multiplicity gives the final logarithmic bound. -/
+theorem Triple.log_c_mul_pred_le_of_liftGrowth_and_excessBudget
+    (T : Triple) {n : ℕ} {σ Cs τ Ce : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hlift : GNLiftRadicalGrowthBudgetAffine T n σ Cs)
+    (hexcess : GNValuationExcessBudgetAffine T n τ Ce) :
+    (((n - 1 : ℕ) : ℝ) * Real.log (T.c : ℝ)) ≤
+      (σ + τ) * Real.log (rad (T.a * T.b * T.c) : ℝ) +
+        (Cs + Ce + Real.log (rad n : ℝ)) := by
+  have hsupport := T.GNSupportBudgetAffine_of_liftGrowth hn ha hb hlift
+  have h := T.log_c_mul_pred_le_of_support_and_excessBudget
+    hn ha hb hsupport hexcess
+  nlinarith
+
+/--
+Explicit ABC constant for the two-budget bridge.
+
+The absolute value avoids a sign split when the affine constant is negative.
+It depends only on `n`, the support constant, and the excess constant.
+-/
+noncomputable def GNABCConstant
+    (n : ℕ) (Cs Ce : ℝ) : ℝ :=
+  max 1 (Real.exp
+    |Cs + Ce + Real.log (rad n : ℝ)|)
+
+theorem one_le_GNABCConstant (n : ℕ) (Cs Ce : ℝ) :
+    (1 : ℝ) ≤ GNABCConstant n Cs Ce :=
+  le_max_left _ _
+
+/-- Pointwise ABC bound obtained from the two independent budgets. -/
+theorem Triple.abc_bound_of_liftGrowth_and_excessBudget
+    (T : Triple) {n : ℕ} {ε σ Cs τ Ce : ℝ}
+    (hn : 2 ≤ n)
+    (ha : 0 < T.a) (hb : 0 < T.b)
+    (hmargin :
+      σ + τ ≤ ((n - 1 : ℕ) : ℝ) * (1 + ε))
+    (hlift : GNLiftRadicalGrowthBudgetAffine T n σ Cs)
+    (hexcess : GNValuationExcessBudgetAffine T n τ Ce) :
+    (T.c : ℝ) ≤
+      GNABCConstant n Cs Ce *
+        (rad (T.a * T.b * T.c) : ℝ) ^ (1 + ε) := by
+  let d : ℝ := ((n - 1 : ℕ) : ℝ)
+  let R : ℝ := (rad (T.a * T.b * T.c) : ℝ)
+  let B : ℝ := Cs + Ce + Real.log (rad n : ℝ)
+  have hd : 1 ≤ d := by
+    dsimp [d]
+    exact_mod_cast (show 1 ≤ n - 1 by omega)
+  have hdpos : 0 < d := lt_of_lt_of_le zero_lt_one hd
+  have hRlog : 0 ≤ Real.log R := by
+    exact le_of_lt (T.log_rad_abc_pos ha hb)
+  have hheight := T.log_c_mul_pred_le_of_liftGrowth_and_excessBudget
+    hn ha hb hlift hexcess
+  change d * Real.log (T.c : ℝ) ≤ (σ + τ) * Real.log R + B at hheight
+  have hcoef :
+      (σ + τ) * Real.log R ≤
+        (d * (1 + ε)) * Real.log R :=
+    mul_le_mul_of_nonneg_right hmargin hRlog
+  have hB : B ≤ d * |B| := by
+    have h1 : B ≤ |B| := le_abs_self B
+    have h2 : |B| ≤ d * |B| := by
+      nlinarith [abs_nonneg B]
+    exact h1.trans h2
+  have hlog :
+      Real.log (T.c : ℝ) ≤
+        (1 + ε) * Real.log R + |B| := by
+    nlinarith
+  have hc : 0 < (T.c : ℝ) := by
+    exact_mod_cast (by rw [← T.hsum]; omega : 0 < T.c)
+  have hR : 0 < R := by
+    dsimp [R]
+    exact_mod_cast rad_pos (by
+      have hcNat : 0 < T.c := by rw [← T.hsum]; omega
+      exact Nat.mul_pos (Nat.mul_pos ha hb) hcNat)
+  have hexp := Real.exp_le_exp.mpr hlog
+  rw [Real.exp_log hc, Real.exp_add] at hexp
+  have hrpow :
+      Real.exp ((1 + ε) * Real.log R) = R ^ (1 + ε) := by
+    rw [mul_comm]
+    exact (Real.rpow_def_of_pos hR _).symm
+  rw [hrpow] at hexp
+  have hconst :
+      Real.exp |B| ≤ GNABCConstant n Cs Ce := by
+    exact le_max_right _ _
+  have hrpow_nonneg : 0 ≤ R ^ (1 + ε) :=
+    Real.rpow_nonneg (le_of_lt hR) _
+  calc
+    (T.c : ℝ) ≤ R ^ (1 + ε) * Real.exp |B| := hexp
+    _ = Real.exp |B| * R ^ (1 + ε) := mul_comm _ _
+    _ ≤ GNABCConstant n Cs Ce * R ^ (1 + ε) :=
+      mul_le_mul_of_nonneg_right hconst hrpow_nonneg
+
+/-- Uniform two-budget contract sufficient for positive-triple ABC. -/
+structure ABCGNFinalBudgetContract (ε : ℝ) where
+  hε : 0 < ε
+  n : ℕ
+  hn : 2 ≤ n
+  σ : ℝ
+  Cs : ℝ
+  τe : ℝ
+  De : ℝ
+  τn : ℝ
+  Dn : ℝ
+  margin :
+    σ + (τe + τn) ≤ ((n - 1 : ℕ) : ℝ) * (1 + ε)
+  liftBudget :
+    ∀ T : Triple, 0 < T.a → 0 < T.b →
+      GNLiftRadicalGrowthBudgetAffine T n σ Cs
+  exceptionalExcessBudget :
+    ∀ T : Triple, 0 < T.a → 0 < T.b →
+      GNExceptionalExcessBudgetAffine T n τe De
+  nonExceptionalExcessBudget :
+    ∀ T : Triple, 0 < T.a → 0 < T.b →
+      GNNonExceptionalExcessBudgetAffine T n τn Dn
+
+/-- The uniform final contract yields a global ABC theorem for positive triples. -/
+theorem abc_positive_of_GNFinalBudgetContract
+    {ε : ℝ}
+    (H : ABCGNFinalBudgetContract ε) :
+    ∃ K : ℝ, 1 ≤ K ∧
+      ∀ T : Triple, 0 < T.a → 0 < T.b →
+        (T.c : ℝ) ≤
+          K * (rad (T.a * T.b * T.c) : ℝ) ^ (1 + ε) := by
+  refine ⟨GNABCConstant H.n H.Cs (H.De + H.Dn),
+    one_le_GNABCConstant _ _ _, ?_⟩
+  intro T ha hb
+  apply T.abc_bound_of_liftGrowth_and_excessBudget
+    H.hn ha hb H.margin (H.liftBudget T ha hb)
+  exact GNValuationExcessBudgetAffine.of_split
+    (H.exceptionalExcessBudget T ha hb)
+    (H.nonExceptionalExcessBudget T ha hb)
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNHighLift.lean
+++ b/lean/dk_math/DkMath/ABC/GNHighLift.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNValuationExcess
+
+#print "file: DkMath.ABC.GNHighLift"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# High-lift primes on GN
+
+This module isolates primes whose square divides a GN kernel.  It separates
+exponent-exceptional high lifts (`q ∣ n`) from non-exceptional high lifts
+(`q ∤ n`) and provides the local no-lift valuation obstruction.
+
+It does not assert that non-exceptional high lifts are globally rare.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/-- A prime whose square divides the selected GN kernel. -/
+def GNHighLiftPrime (q n a b : ℕ) : Prop :=
+  Nat.Prime q ∧ q ^ 2 ∣ GN n a b
+
+/-- A GN high lift carried by a prime divisor of the exponent. -/
+def GNExceptionalHighLiftPrime (q n a b : ℕ) : Prop :=
+  GNHighLiftPrime q n a b ∧ q ∣ n
+
+/-- A GN high lift carried by a prime not dividing the exponent. -/
+def GNNonExceptionalHighLiftPrime (q n a b : ℕ) : Prop :=
+  GNHighLiftPrime q n a b ∧ ¬ q ∣ n
+
+/-- Every GN high lift lies in exactly one of the two exponent layers. -/
+theorem GNHighLiftPrime.exceptional_or_nonExceptional
+    {q n a b : ℕ} (h : GNHighLiftPrime q n a b) :
+    GNExceptionalHighLiftPrime q n a b ∨
+      GNNonExceptionalHighLiftPrime q n a b := by
+  by_cases hqn : q ∣ n
+  · exact Or.inl ⟨h, hqn⟩
+  · exact Or.inr ⟨h, hqn⟩
+
+/-- The exceptional and non-exceptional high-lift layers are disjoint. -/
+theorem not_exceptional_and_nonExceptional_highLift
+    (q n a b : ℕ) :
+    ¬ (GNExceptionalHighLiftPrime q n a b ∧
+      GNNonExceptionalHighLiftPrime q n a b) := by
+  rintro ⟨⟨_, hqn⟩, ⟨_, hqn'⟩⟩
+  exact hqn' hqn
+
+/-- A non-exceptional GN high-lift prime cannot divide the ABC boundary. -/
+theorem Triple.nonExceptionalHighLift_not_dvd_boundary
+    (T : Triple) {n q : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a)
+    (h : GNNonExceptionalHighLiftPrime q n T.a T.b) :
+    ¬ q ∣ T.a := by
+  exact T.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+    hn ha h.2 (dvd_trans (dvd_pow_self q (by decide : (2 : ℕ) ≠ 0)) h.1.2)
+
+/-- A GN high lift has valuation at least two. -/
+theorem two_le_padicValNat_GN_of_highLift
+    {q n a b : ℕ} (hGN : GN n a b ≠ 0)
+    (h : GNHighLiftPrime q n a b) :
+    2 ≤ padicValNat q (GN n a b) := by
+  exact (DkMath.ABC.padicValNat_le_iff_dvd h.1 hGN 2).2 h.2
+
+/-- Absence of a square lift bounds the GN valuation by one. -/
+theorem padicValNat_GN_le_one_of_noHighLift
+    {q n a b : ℕ} (hq : Nat.Prime q) (hGN : GN n a b ≠ 0)
+    (hNoLift : ¬ q ^ 2 ∣ GN n a b) :
+    padicValNat q (GN n a b) ≤ 1 := by
+  by_contra hle
+  have htwo : 2 ≤ padicValNat q (GN n a b) := by omega
+  exact hNoLift ((DkMath.ABC.padicValNat_le_iff_dvd hq hGN 2).1 htwo)
+
+/--
+On a non-exceptional GN channel with no square lift, the full power-difference
+valuation is at most one.
+-/
+theorem Triple.padic_powerDiff_le_one_of_nonExceptional_noHighLift
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hq : Nat.Prime q) (hq_exp : ¬ q ∣ n)
+    (hq_GN : q ∣ GN n T.a T.b)
+    (hNoLift : ¬ q ^ 2 ∣ GN n T.a T.b) :
+    padicValNat q (T.c ^ n - T.b ^ n) ≤ 1 := by
+  rw [T.padic_powerDiff_eq_GN_of_not_dvd_exp_of_dvd_GN
+    hn ha hb hq hq_exp hq_GN]
+  exact padicValNat_GN_le_one_of_noHighLift hq
+    (GN_ne_zero_nat_of_two_le hn ha hb) hNoLift
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNHighLift.lean
+++ b/lean/dk_math/DkMath/ABC/GNHighLift.lean
@@ -37,6 +37,65 @@ def GNExceptionalHighLiftPrime (q n a b : ℕ) : Prop :=
 def GNNonExceptionalHighLiftPrime (q n a b : ℕ) : Prop :=
   GNHighLiftPrime q n a b ∧ ¬ q ∣ n
 
+/-- The finite factorization support carried by prime-square divisors. -/
+def highLiftSupport (m : ℕ) : Finset ℕ :=
+  m.factorization.support.filter (fun q => q ^ 2 ∣ m)
+
+/--
+Valuation excess is supported exactly on prime-square carriers; support
+primes of valuation one make a zero contribution.
+-/
+theorem valuationExcess_eq_sum_highLift
+    {m : ℕ} (hm : m ≠ 0) :
+    valuationExcess m =
+      ∑ q ∈ highLiftSupport m,
+        (((m.factorization q - 1 : ℕ) : ℝ) *
+          Real.log (q : ℝ)) := by
+  classical
+  unfold valuationExcess highLiftSupport
+  symm
+  apply Finset.sum_subset (Finset.filter_subset _ _)
+  intro q hq hq_filter
+  have hq_support : q ∈ m.factorization.support := hq
+  have hq_prime : Nat.Prime q :=
+    (mem_support_factorization_iff.mp hq_support).2.1
+  have hq_not_sq : ¬ q ^ 2 ∣ m := by
+    intro hsq
+    exact hq_filter (Finset.mem_filter.mpr ⟨hq_support, hsq⟩)
+  have hq_lt_two : ¬ 2 ≤ m.factorization q := by
+    intro htwo
+    exact hq_not_sq
+      ((hq_prime.pow_dvd_iff_le_factorization hm).2 htwo)
+  have hq_one : m.factorization q = 1 := by
+    have := one_le_factorization_of_mem_support hq_support
+    omega
+  simp [hq_one]
+
+/-- GN valuation excess is the exact finite sum over GN high-lift carriers. -/
+theorem GNValuationExcess_eq_sum_highLift
+    {n a b : ℕ} (hGN : GN n a b ≠ 0) :
+    GNValuationExcess n a b =
+      ∑ q ∈ highLiftSupport (GN n a b),
+        ((((GN n a b).factorization q - 1 : ℕ) : ℝ) *
+          Real.log (q : ℝ)) := by
+  simpa [GNValuationExcess] using
+    (valuationExcess_eq_sum_highLift (m := GN n a b) hGN)
+
+/-- If GN has no prime-square carrier, its valuation excess vanishes. -/
+theorem GNValuationExcess_eq_zero_of_no_highLift
+    {n a b : ℕ} (hGN : GN n a b ≠ 0)
+    (hNoLift : ∀ q, Nat.Prime q → ¬ q ^ 2 ∣ GN n a b) :
+    GNValuationExcess n a b = 0 := by
+  rw [GNValuationExcess_eq_sum_highLift hGN]
+  apply Finset.sum_eq_zero
+  intro q hq
+  have hq_support :
+      q ∈ (GN n a b).factorization.support :=
+    (Finset.mem_filter.mp hq).1
+  have hq_prime : Nat.Prime q :=
+    (mem_support_factorization_iff.mp hq_support).2.1
+  exact False.elim (hNoLift q hq_prime (Finset.mem_filter.mp hq).2)
+
 /-- Every GN high lift lies in exactly one of the two exponent layers. -/
 theorem GNHighLiftPrime.exceptional_or_nonExceptional
     {q n a b : ℕ} (h : GNHighLiftPrime q n a b) :

--- a/lean/dk_math/DkMath/ABC/GNPowerLift.lean
+++ b/lean/dk_math/DkMath/ABC/GNPowerLift.lean
@@ -78,4 +78,39 @@ theorem Triple.gnPowerLift_coprime (T : Triple) (n : ℕ) :
     Nat.Coprime (T.a * GN n T.a T.b) (T.b ^ n) :=
   (T.gnPowerLift n).hcop
 
+/--
+The GN difference quotient contains at least the leading endpoint
+`c^(n-1)`.  This is the natural-coordinate return bound used by the
+quality-to-excess bridge.
+-/
+theorem Triple.pow_pred_c_le_GN
+    (T : Triple) {n : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a) :
+    T.c ^ (n - 1) ≤ GN n T.a T.b := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hn
+  simp only [Nat.add_sub_cancel_left]
+  have hbc : T.b ≤ T.c := by
+    rw [← T.hsum]
+    exact Nat.le_add_left T.b T.a
+  have hpow : T.b ^ k ≤ T.c ^ k :=
+    Nat.pow_le_pow_left hbc k
+  have hbpow : T.b ^ (1 + k) ≤ T.b * T.c ^ k := by
+    rw [Nat.add_comm, pow_succ']
+    exact Nat.mul_le_mul_left T.b hpow
+  have hsum := T.gnPowerLift_sum (1 + k)
+  have hleft :
+      T.a * T.c ^ k + T.b ^ (1 + k) ≤
+        (T.a + T.b) * T.c ^ k := by
+    rw [add_mul]
+    exact Nat.add_le_add_left hbpow _
+  have hmul : T.a * T.c ^ k ≤ T.a * GN (1 + k) T.a T.b := by
+    apply Nat.le_of_add_le_add_right
+    calc
+      T.a * T.c ^ k + T.b ^ (1 + k)
+          ≤ (T.a + T.b) * T.c ^ k := hleft
+      _ = T.c ^ (1 + k) := by
+        rw [T.hsum, Nat.add_comm, pow_succ']
+      _ = T.a * GN (1 + k) T.a T.b + T.b ^ (1 + k) := hsum.symm
+  exact Nat.le_of_mul_le_mul_left hmul ha
+
 end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNPowerLift.lean
+++ b/lean/dk_math/DkMath/ABC/GNPowerLift.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.Triple
+import DkMath.CosmicFormula.CosmicFormulaBinom
+
+#print "file: DkMath.ABC.GNPowerLift"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# ABC triples lifted through `GN`
+
+For an additive coprime triple `a + b = c`, the Cosmic Formula identity
+
+`(a + b) ^ n = a * GN n a b + b ^ n`
+
+produces another additive coprime triple.  This module packages that first
+deterministic ABC–GN bridge without making any claim about ABC quality or
+valuation excess.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/--
+Lift an ABC triple `a + b = c` along the `n`th-power Cosmic Formula identity.
+
+The lifted coordinates are
+`a * GN n a b`, `b ^ n`, and `c ^ n`.  This is valid for every natural
+exponent, including `n = 0`.
+-/
+def Triple.gnPowerLift (T : Triple) (n : ℕ) : Triple where
+  a := T.a * GN n T.a T.b
+  b := T.b ^ n
+  c := T.c ^ n
+  hsum := by
+    calc
+      T.a * GN n T.a T.b + T.b ^ n = (T.a + T.b) ^ n := by
+        symm
+        exact cosmic_id_csr' n T.a T.b
+      _ = T.c ^ n := by rw [T.hsum]
+  hcop := by
+    apply (Nat.coprime_add_self_left).1
+    rw [← cosmic_id_csr' n T.a T.b, T.hsum]
+    have hcb : Nat.Coprime T.c T.b := by
+      rw [← T.hsum]
+      exact (Nat.coprime_add_self_left).2 T.hcop
+    exact Nat.Coprime.pow n n hcb
+
+@[simp]
+theorem Triple.gnPowerLift_a (T : Triple) (n : ℕ) :
+    (T.gnPowerLift n).a = T.a * GN n T.a T.b :=
+  rfl
+
+@[simp]
+theorem Triple.gnPowerLift_b (T : Triple) (n : ℕ) :
+    (T.gnPowerLift n).b = T.b ^ n :=
+  rfl
+
+@[simp]
+theorem Triple.gnPowerLift_c (T : Triple) (n : ℕ) :
+    (T.gnPowerLift n).c = T.c ^ n :=
+  rfl
+
+/-- The additive equation underlying the GN power lift. -/
+theorem Triple.gnPowerLift_sum (T : Triple) (n : ℕ) :
+    T.a * GN n T.a T.b + T.b ^ n = T.c ^ n :=
+  (T.gnPowerLift n).hsum
+
+/-- The lifted left coordinate is coprime to the lifted right coordinate. -/
+theorem Triple.gnPowerLift_coprime (T : Triple) (n : ℕ) :
+    Nat.Coprime (T.a * GN n T.a T.b) (T.b ^ n) :=
+  (T.gnPowerLift n).hcop
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
+++ b/lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
@@ -17,13 +17,15 @@ set_option linter.style.emptyLine false
 # The quality-to-GN-excess interface
 
 This module records the exact deterministic interface needed to turn high ABC
-quality into GN valuation excess.  Two estimates remain visible:
+quality into GN valuation excess.  Two estimates are visible in the generic
+interface:
 
 * a return lower bound comparing `log GN` with `log c`;
 * a support budget comparing `log (rad GN)` with the ABC radical.
 
-Neither estimate is asserted globally here.  Once supplied, the finite
-factorization identity forces the claimed excess.
+The GN return estimate is discharged unconditionally below with coefficient
+`n - 1`.  Thus the specialized public bridge leaves only the GN support
+budget as a global input.
 -/
 
 namespace DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
+++ b/lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNValuationExcess
+import DkMath.ABC.AdjacentDiagonalBasic
+
+#print "file: DkMath.ABC.GNQualityExcessBridge"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# The quality-to-GN-excess interface
+
+This module records the exact deterministic interface needed to turn high ABC
+quality into GN valuation excess.  Two estimates remain visible:
+
+* a return lower bound comparing `log GN` with `log c`;
+* a support budget comparing `log (rad GN)` with the ABC radical.
+
+Neither estimate is asserted globally here.  Once supplied, the finite
+factorization identity forces the claimed excess.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/-- The GN kernel returns at least `κ` copies of the logarithmic ABC height. -/
+def GNReturnLowerBound (T : Triple) (n : ℕ) (κ : ℝ) : Prop :=
+  κ * Real.log (T.c : ℝ) ≤ Real.log ((GN n T.a T.b : ℕ) : ℝ)
+
+/-- The radical support of GN consumes at most `σ` ABC-radical log units. -/
+def GNSupportBudget (T : Triple) (n : ℕ) (σ : ℝ) : Prop :=
+  Real.log (rad (GN n T.a T.b) : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ)
+
+/-- High quality is exactly a strict lower bound for `log c` when the denominator is positive. -/
+theorem log_c_gt_of_quality_gt
+    (T : Triple) {Q : ℝ}
+    (hrad : 0 < Real.log (rad (T.a * T.b * T.c) : ℝ))
+    (hquality : Q < quality T) :
+    Q * Real.log (rad (T.a * T.b * T.c) : ℝ) <
+      Real.log (T.c : ℝ) := by
+  rw [quality] at hquality
+  exact (lt_div_iff₀ hrad).mp hquality
+
+/--
+The deterministic high-quality-to-excess bridge.
+
+The theorem deliberately exposes the two estimates that a global argument
+must establish.  Its conclusion is unconditional once those estimates and
+the finite GN identity are available.
+-/
+theorem Triple.GNValuationExcess_gt_of_quality_gt
+    (T : Triple) {n : ℕ} {ε κ σ : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hrad : 0 < Real.log (rad (T.a * T.b * T.c) : ℝ))
+    (hκ : 0 < κ)
+    (hquality : 1 + ε < quality T)
+    (hreturn : GNReturnLowerBound T n κ)
+    (hsupport : GNSupportBudget T n σ) :
+    (κ * (1 + ε) - σ) *
+        Real.log (rad (T.a * T.b * T.c) : ℝ) <
+      GNValuationExcess n T.a T.b := by
+  have hheight := log_c_gt_of_quality_gt T hrad hquality
+  have hscaled :
+      κ * ((1 + ε) * Real.log (rad (T.a * T.b * T.c) : ℝ)) <
+        κ * Real.log (T.c : ℝ) := by
+    exact mul_lt_mul_of_pos_left hheight hκ
+  have hidentity := T.log_GN_eq_log_rad_add_GNValuationExcess hn ha hb
+  change κ * Real.log (T.c : ℝ) ≤
+    Real.log ((GN n T.a T.b : ℕ) : ℝ) at hreturn
+  change Real.log (rad (GN n T.a T.b) : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) at hsupport
+  nlinarith
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
+++ b/lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
@@ -6,6 +6,7 @@ Authors: D. and Wise Wolf.
 
 import DkMath.ABC.GNValuationExcess
 import DkMath.ABC.AdjacentDiagonalBasic
+import DkMath.ABC.TailRadicalBasic
 
 #print "file: DkMath.ABC.GNQualityExcessBridge"
 
@@ -37,6 +38,56 @@ def GNReturnLowerBound (T : Triple) (n : ℕ) (κ : ℝ) : Prop :=
 def GNSupportBudget (T : Triple) (n : ℕ) (σ : ℝ) : Prop :=
   Real.log (rad (GN n T.a T.b) : ℝ) ≤
     σ * Real.log (rad (T.a * T.b * T.c) : ℝ)
+
+/-- Affine GN-support budget, allowing an additive finite-exception constant. -/
+def GNSupportBudgetAffine
+    (T : Triple) (n : ℕ) (σ C : ℝ) : Prop :=
+  Real.log (rad (GN n T.a T.b) : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) + C
+
+/-- The pure support budget is the zero-constant affine budget. -/
+theorem GNSupportBudget.toAffine
+    {T : Triple} {n : ℕ} {σ : ℝ}
+    (h : GNSupportBudget T n σ) :
+    GNSupportBudgetAffine T n σ 0 := by
+  simpa [GNSupportBudget, GNSupportBudgetAffine] using h
+
+/-- Positive ABC coordinates make the ABC radical logarithm strictly positive. -/
+theorem Triple.log_rad_abc_pos
+    (T : Triple) (ha : 0 < T.a) (hb : 0 < T.b) :
+    0 < Real.log (rad (T.a * T.b * T.c) : ℝ) := by
+  have hprod : 2 ≤ T.a * T.b * T.c := by
+    have hab : 1 ≤ T.a * T.b := Nat.one_le_iff_ne_zero.mpr
+      (Nat.mul_ne_zero (Nat.ne_of_gt ha) (Nat.ne_of_gt hb))
+    have hc : 2 ≤ T.c := by
+      rw [← T.hsum]
+      omega
+    nlinarith
+  exact log_rad_pos_of_two_le hprod
+
+/-- The natural GN endpoint bound gives the unconditional logarithmic return. -/
+theorem Triple.log_c_mul_pred_le_log_GN
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) :
+    (((n - 1 : ℕ) : ℝ) * Real.log (T.c : ℝ)) ≤
+      Real.log ((GN n T.a T.b : ℕ) : ℝ) := by
+  have hnat := T.pow_pred_c_le_GN (Nat.one_le_of_lt hn) ha
+  have hc : 0 < (T.c : ℝ) := by
+    exact_mod_cast (by rw [← T.hsum]; omega : 0 < T.c)
+  have hcast :
+      ((T.c ^ (n - 1) : ℕ) : ℝ) ≤
+        ((GN n T.a T.b : ℕ) : ℝ) := by
+    exact_mod_cast hnat
+  rw [Nat.cast_pow] at hcast
+  have hlog := Real.log_le_log (pow_pos hc _) hcast
+  simpa [Nat.cast_pow, Real.log_pow] using hlog
+
+/-- `κ = n-1` discharges the return predicate without a global hypothesis. -/
+theorem Triple.gnReturnLowerBound_pred
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNReturnLowerBound T n ((n - 1 : ℕ) : ℝ) := by
+  exact T.log_c_mul_pred_le_log_GN hn ha hb
 
 /-- High quality is exactly a strict lower bound for `log c` when the denominator is positive. -/
 theorem log_c_gt_of_quality_gt
@@ -77,5 +128,54 @@ theorem Triple.GNValuationExcess_gt_of_quality_gt
   change Real.log (rad (GN n T.a T.b) : ℝ) ≤
     σ * Real.log (rad (T.a * T.b * T.c) : ℝ) at hsupport
   nlinarith
+
+/-- Affine version of the deterministic high-quality-to-excess bridge. -/
+theorem Triple.GNValuationExcess_gt_of_quality_gt_affine
+    (T : Triple) {n : ℕ} {ε κ σ C : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hκ : 0 < κ)
+    (hquality : 1 + ε < quality T)
+    (hreturn : GNReturnLowerBound T n κ)
+    (hsupport : GNSupportBudgetAffine T n σ C) :
+    (κ * (1 + ε) - σ) *
+          Real.log (rad (T.a * T.b * T.c) : ℝ) - C <
+      GNValuationExcess n T.a T.b := by
+  have hrad := T.log_rad_abc_pos ha hb
+  have hheight := log_c_gt_of_quality_gt T hrad hquality
+  have hscaled :
+      κ * ((1 + ε) * Real.log (rad (T.a * T.b * T.c) : ℝ)) <
+        κ * Real.log (T.c : ℝ) :=
+    mul_lt_mul_of_pos_left hheight hκ
+  have hidentity := T.log_GN_eq_log_rad_add_GNValuationExcess hn ha hb
+  change κ * Real.log (T.c : ℝ) ≤
+    Real.log ((GN n T.a T.b : ℕ) : ℝ) at hreturn
+  change Real.log (rad (GN n T.a T.b) : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) + C at hsupport
+  nlinarith
+
+/-- High quality forces GN excess assuming only an affine support budget. -/
+theorem Triple.GNValuationExcess_gt_of_quality_gt_pred_affine
+    (T : Triple) {n : ℕ} {ε σ C : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hquality : 1 + ε < quality T)
+    (hsupport : GNSupportBudgetAffine T n σ C) :
+    ((((n - 1 : ℕ) : ℝ) * (1 + ε) - σ) *
+          Real.log (rad (T.a * T.b * T.c) : ℝ)) - C <
+      GNValuationExcess n T.a T.b := by
+  exact T.GNValuationExcess_gt_of_quality_gt_affine hn ha hb
+    (by exact_mod_cast (show 0 < n - 1 by omega))
+    hquality (T.gnReturnLowerBound_pred hn ha hb) hsupport
+
+/-- Pure-budget specialization of the unconditional GN return bridge. -/
+theorem Triple.GNValuationExcess_gt_of_quality_gt_pred
+    (T : Triple) {n : ℕ} {ε σ : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hquality : 1 + ε < quality T)
+    (hsupport : GNSupportBudget T n σ) :
+    (((n - 1 : ℕ) : ℝ) * (1 + ε) - σ) *
+        Real.log (rad (T.a * T.b * T.c) : ℝ) <
+      GNValuationExcess n T.a T.b := by
+  simpa using T.GNValuationExcess_gt_of_quality_gt_pred_affine
+    hn ha hb hquality hsupport.toAffine
 
 end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNSupportReturn.lean
+++ b/lean/dk_math/DkMath/ABC/GNSupportReturn.lean
@@ -1,0 +1,330 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNQualityExcessBridge
+import DkMath.ABC.MassBridge
+
+#print "file: DkMath.ABC.GNSupportReturn"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# Exceptional GN support and lifted-radical return
+
+Exponent-prime support is absorbed into `rad n`.  The complementary GN
+support is fresh relative to the original ABC triple and returns as new
+squarefree support in the GN power lift.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+def GNExceptionalSupport (n a b : ℕ) : Finset ℕ :=
+  (GN n a b).factorization.support.filter (fun q => q ∣ n)
+
+def GNNonExceptionalSupport (n a b : ℕ) : Finset ℕ :=
+  (GN n a b).factorization.support.filter (fun q => ¬ q ∣ n)
+
+def GNExceptionalSupportProduct (n a b : ℕ) : ℕ :=
+  (GNExceptionalSupport n a b).prod id
+
+def GNNonExceptionalSupportProduct (n a b : ℕ) : ℕ :=
+  (GNNonExceptionalSupport n a b).prod id
+
+theorem GNExceptionalSupportProduct_pos (n a b : ℕ) :
+    0 < GNExceptionalSupportProduct n a b := by
+  unfold GNExceptionalSupportProduct
+  apply Finset.prod_pos
+  intro q hq
+  exact Nat.Prime.pos
+    (mem_support_factorization_iff.mp (Finset.mem_filter.mp hq).1).2.1
+
+theorem GNNonExceptionalSupportProduct_pos (n a b : ℕ) :
+    0 < GNNonExceptionalSupportProduct n a b := by
+  unfold GNNonExceptionalSupportProduct
+  apply Finset.prod_pos
+  intro q hq
+  exact Nat.Prime.pos
+    (mem_support_factorization_iff.mp (Finset.mem_filter.mp hq).1).2.1
+
+/-- Exact finite partition of GN prime support by divisibility of the exponent. -/
+theorem GN_support_eq_exceptional_union_nonExceptional
+    (n a b : ℕ) :
+    (GN n a b).factorization.support =
+      GNExceptionalSupport n a b ∪ GNNonExceptionalSupport n a b := by
+  classical
+  ext q
+  simp only [GNExceptionalSupport, GNNonExceptionalSupport,
+    Finset.mem_union, Finset.mem_filter]
+  tauto
+
+/-- The two exponent layers of GN support are disjoint. -/
+theorem GNExceptionalSupport_disjoint_nonExceptional
+    (n a b : ℕ) :
+    Disjoint (GNExceptionalSupport n a b)
+      (GNNonExceptionalSupport n a b) := by
+  classical
+  refine Finset.disjoint_left.mpr ?_
+  intro q hqE hqN
+  exact (Finset.mem_filter.mp hqN).2 (Finset.mem_filter.mp hqE).2
+
+/-- Exact radical product identity for the two GN support layers. -/
+theorem rad_GN_eq_exceptional_mul_nonExceptional
+    (n a b : ℕ) :
+    rad (GN n a b) =
+      GNExceptionalSupportProduct n a b *
+        GNNonExceptionalSupportProduct n a b := by
+  unfold rad GNExceptionalSupportProduct GNNonExceptionalSupportProduct
+  rw [GN_support_eq_exceptional_union_nonExceptional]
+  exact Finset.prod_union
+    (GNExceptionalSupport_disjoint_nonExceptional n a b)
+
+/-- All exponent-exceptional GN support is absorbed by the radical of `n`. -/
+theorem GNExceptionalSupportProduct_dvd_rad
+    {n a b : ℕ} (hn : 1 ≤ n) :
+    GNExceptionalSupportProduct n a b ∣ rad n := by
+  rw [← supportMass_eq_abc_rad]
+  apply prime_channel_family_prod_dvd_supportMass (Nat.ne_of_gt hn)
+  intro q hq
+  have hq' := Finset.mem_filter.mp hq
+  exact ⟨(mem_support_factorization_iff.mp hq'.1).2.1, hq'.2⟩
+
+/-- Logarithmic absorption of exceptional GN support. -/
+theorem log_GNExceptionalSupportProduct_le_log_rad
+    {n a b : ℕ} (hn : 1 ≤ n) :
+    Real.log (GNExceptionalSupportProduct n a b : ℝ) ≤
+      Real.log (rad n : ℝ) := by
+  have hdiv := GNExceptionalSupportProduct_dvd_rad
+    (n := n) (a := a) (b := b) hn
+  have hpos : 0 < (GNExceptionalSupportProduct n a b : ℝ) := by
+    exact_mod_cast GNExceptionalSupportProduct_pos n a b
+  apply Real.log_le_log hpos
+  exact_mod_cast Nat.le_of_dvd (rad_pos (Nat.zero_lt_of_lt hn)) hdiv
+
+/-- Full GN support is bounded by the exponent radical plus fresh support. -/
+theorem log_rad_GN_le_log_rad_exp_add_log_nonExceptional
+    {n a b : ℕ} (hn : 1 ≤ n) :
+    Real.log (rad (GN n a b) : ℝ) ≤
+      Real.log (rad n : ℝ) +
+        Real.log (GNNonExceptionalSupportProduct n a b : ℝ) := by
+  rw [rad_GN_eq_exceptional_mul_nonExceptional, Nat.cast_mul,
+    Real.log_mul
+      (by exact_mod_cast (Nat.ne_of_gt (GNExceptionalSupportProduct_pos n a b)))
+      (by exact_mod_cast (Nat.ne_of_gt (GNNonExceptionalSupportProduct_pos n a b)))]
+  linarith [log_GNExceptionalSupportProduct_le_log_rad
+    (n := n) (a := a) (b := b) hn]
+
+/-- A non-exceptional GN support prime is fresh relative to all original coordinates. -/
+theorem Triple.nonExceptionalSupport_fresh
+    (T : Triple) {n q : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a)
+    (hq : q ∈ GNNonExceptionalSupport n T.a T.b) :
+    Nat.Prime q ∧ q ∣ GN n T.a T.b ∧
+      ¬ q ∣ T.a ∧ ¬ q ∣ T.b ∧ ¬ q ∣ T.c ∧
+        ¬ q ∣ T.a * T.b * T.c := by
+  have hmem := Finset.mem_filter.mp hq
+  rcases mem_support_factorization_iff.mp hmem.1 with ⟨_, hprime, hqGN⟩
+  have hqa := T.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+    hn ha hmem.2 hqGN
+  have hqLiftA : q ∣ (T.gnPowerLift n).a :=
+    dvd_mul_of_dvd_right hqGN T.a
+  have hqb : ¬ q ∣ T.b := by
+    intro hqb
+    have hqLiftB : q ∣ (T.gnPowerLift n).b :=
+      dvd_pow hqb (Nat.ne_of_gt hn)
+    have hqgcd : q ∣ Nat.gcd (T.gnPowerLift n).a
+        (T.gnPowerLift n).b := Nat.dvd_gcd hqLiftA hqLiftB
+    have hcop := (T.gnPowerLift n).hcop
+    rw [Nat.coprime_iff_gcd_eq_one] at hcop
+    rw [hcop] at hqgcd
+    exact hprime.not_dvd_one hqgcd
+  have hqc : ¬ q ∣ T.c := by
+    intro hqc
+    have hqLiftC : q ∣ (T.gnPowerLift n).c :=
+      dvd_pow hqc (Nat.ne_of_gt hn)
+    have hcopAC : Nat.Coprime (T.gnPowerLift n).a
+        (T.gnPowerLift n).c := by
+      rw [← (T.gnPowerLift n).hsum]
+      simpa [add_comm] using
+        (Nat.coprime_add_self_right).2 (T.gnPowerLift n).hcop
+    have hqgcd : q ∣ Nat.gcd (T.gnPowerLift n).a
+        (T.gnPowerLift n).c := Nat.dvd_gcd hqLiftA hqLiftC
+    rw [hcopAC] at hqgcd
+    exact hprime.not_dvd_one hqgcd
+  refine ⟨hprime, hqGN, hqa, hqb, hqc, ?_⟩
+  intro hqabc
+  rcases hprime.dvd_mul.mp hqabc with hqab | hqc'
+  · rcases hprime.dvd_mul.mp hqab with hqa' | hqb'
+    · exact hqa hqa'
+    · exact hqb hqb'
+  · exact hqc hqc'
+
+/--
+The original radical together with all fresh non-exceptional GN support
+divides the radical of the lifted ABC product.
+-/
+theorem Triple.rad_mul_nonExceptionalProduct_dvd_lift_rad
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) :
+    rad (T.a * T.b * T.c) *
+        GNNonExceptionalSupportProduct n T.a T.b ∣
+      rad ((T.gnPowerLift n).a *
+        (T.gnPowerLift n).b * (T.gnPowerLift n).c) := by
+  let S := (T.a * T.b * T.c).factorization.support ∪
+    GNNonExceptionalSupport n T.a T.b
+  have hdis :
+      Disjoint (T.a * T.b * T.c).factorization.support
+        (GNNonExceptionalSupport n T.a T.b) := by
+    refine Finset.disjoint_left.mpr ?_
+    intro q hqabc hqGN
+    exact (T.nonExceptionalSupport_fresh (Nat.one_le_of_lt hn) ha hqGN).2.2.2.2.2
+      (mem_support_factorization_iff.mp hqabc).2.2
+  have hprod :
+      S.prod id =
+        rad (T.a * T.b * T.c) *
+          GNNonExceptionalSupportProduct n T.a T.b := by
+    unfold S GNNonExceptionalSupportProduct rad
+    simpa only [id_eq] using Finset.prod_union hdis
+  rw [← hprod, ← supportMass_eq_abc_rad]
+  apply prime_channel_family_prod_dvd_supportMass
+    (by
+      simp only [Triple.gnPowerLift_a, Triple.gnPowerLift_b,
+        Triple.gnPowerLift_c]
+      exact Nat.mul_ne_zero
+        (Nat.mul_ne_zero
+            (Nat.mul_ne_zero (Nat.ne_of_gt ha)
+            (GN_ne_zero_nat_of_two_le hn ha hb))
+          (pow_ne_zero n (Nat.ne_of_gt hb)))
+        (pow_ne_zero n (by
+          rw [← T.hsum]
+          omega)))
+  intro q hqS
+  rcases Finset.mem_union.mp hqS with hqabc | hqGN
+  · rcases mem_support_factorization_iff.mp hqabc with ⟨_, hp, hd⟩
+    refine ⟨hp, ?_⟩
+    rcases hp.dvd_mul.mp hd with hab | hc
+    · rcases hp.dvd_mul.mp hab with ha' | hb'
+      · change q ∣ (T.a * GN n T.a T.b) * T.b ^ n * T.c ^ n
+        exact dvd_mul_of_dvd_left
+          (dvd_mul_of_dvd_left
+            (dvd_mul_of_dvd_left ha' (GN n T.a T.b)) _) _
+      · change q ∣ (T.a * GN n T.a T.b) * T.b ^ n * T.c ^ n
+        exact dvd_mul_of_dvd_left
+          (dvd_mul_of_dvd_right
+            (dvd_pow hb' (Nat.ne_of_gt (lt_of_lt_of_le Nat.zero_lt_two hn))) _) _
+    · change q ∣ (T.a * GN n T.a T.b) * T.b ^ n * T.c ^ n
+      exact dvd_mul_of_dvd_right
+        (dvd_pow hc (Nat.ne_of_gt (lt_of_lt_of_le Nat.zero_lt_two hn))) _
+  · have hfresh := T.nonExceptionalSupport_fresh (Nat.one_le_of_lt hn) ha hqGN
+    refine ⟨hfresh.1, ?_⟩
+    change q ∣ (T.a * GN n T.a T.b) * T.b ^ n * T.c ^ n
+    exact dvd_mul_of_dvd_left
+      (dvd_mul_of_dvd_left
+        (dvd_mul_of_dvd_right hfresh.2.1 T.a) (T.b ^ n)) _
+
+/-- Logarithmic form of fresh radical growth in the GN power lift. -/
+theorem Triple.log_rad_add_log_nonExceptional_le_log_lift_rad
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) :
+    Real.log (rad (T.a * T.b * T.c) : ℝ) +
+        Real.log (GNNonExceptionalSupportProduct n T.a T.b : ℝ) ≤
+      Real.log (rad ((T.gnPowerLift n).a *
+        (T.gnPowerLift n).b * (T.gnPowerLift n).c) : ℝ) := by
+  have hc : 0 < T.c := by
+    rw [← T.hsum]
+    omega
+  have habcPos : 0 < T.a * T.b * T.c :=
+    Nat.mul_pos (Nat.mul_pos ha hb) hc
+  rw [← Real.log_mul
+    (by exact_mod_cast (Nat.ne_of_gt
+      (rad_pos habcPos)))
+    (by exact_mod_cast (Nat.ne_of_gt
+      (GNNonExceptionalSupportProduct_pos n T.a T.b))),
+    ← Nat.cast_mul]
+  apply Real.log_le_log (by
+    exact_mod_cast Nat.mul_pos (rad_pos habcPos)
+      (GNNonExceptionalSupportProduct_pos n T.a T.b))
+  have hliftPos :
+      0 < (T.gnPowerLift n).a *
+        (T.gnPowerLift n).b * (T.gnPowerLift n).c := by
+    simp only [Triple.gnPowerLift_a, Triple.gnPowerLift_b,
+      Triple.gnPowerLift_c]
+    exact Nat.mul_pos
+      (Nat.mul_pos (Nat.mul_pos ha
+        (Nat.pos_of_ne_zero (GN_ne_zero_nat_of_two_le hn ha hb)))
+        (pow_pos hb n))
+      (pow_pos (by rw [← T.hsum]; omega) n)
+  exact_mod_cast Nat.le_of_dvd (rad_pos hliftPos)
+    (T.rad_mul_nonExceptionalProduct_dvd_lift_rad hn ha hb)
+
+/-- Affine upper budget for the radical growth of the GN power lift. -/
+def GNLiftRadicalGrowthBudgetAffine
+    (T : Triple) (n : ℕ) (σ C : ℝ) : Prop :=
+  Real.log (rad ((T.gnPowerLift n).a *
+      (T.gnPowerLift n).b * (T.gnPowerLift n).c) : ℝ) ≤
+    (1 + σ) * Real.log (rad (T.a * T.b * T.c) : ℝ) + C
+
+/-- Affine upper budget for fresh non-exceptional GN support. -/
+def GNNonExceptionalSupportBudgetAffine
+    (T : Triple) (n : ℕ) (σ C : ℝ) : Prop :=
+  Real.log (GNNonExceptionalSupportProduct n T.a T.b : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) + C
+
+/-- Lifted-radical growth controls fresh non-exceptional support. -/
+theorem Triple.nonExceptionalSupportBudgetAffine_of_liftGrowth
+    (T : Triple) {n : ℕ} {σ C : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (h : GNLiftRadicalGrowthBudgetAffine T n σ C) :
+    GNNonExceptionalSupportBudgetAffine T n σ C := by
+  have hlower := T.log_rad_add_log_nonExceptional_le_log_lift_rad hn ha hb
+  change Real.log (rad ((T.gnPowerLift n).a *
+      (T.gnPowerLift n).b * (T.gnPowerLift n).c) : ℝ) ≤
+    (1 + σ) * Real.log (rad (T.a * T.b * T.c) : ℝ) + C at h
+  dsimp [GNNonExceptionalSupportBudgetAffine]
+  linarith
+
+/-- Fresh-support budget plus finite exponent support gives the full affine budget. -/
+theorem Triple.GNSupportBudgetAffine_of_nonExceptional
+    (T : Triple) {n : ℕ} {σ C : ℝ}
+    (hn : 1 ≤ n)
+    (h : GNNonExceptionalSupportBudgetAffine T n σ C) :
+    GNSupportBudgetAffine T n σ
+      (C + Real.log (rad n : ℝ)) := by
+  have hsplit := log_rad_GN_le_log_rad_exp_add_log_nonExceptional
+    (n := n) (a := T.a) (b := T.b) hn
+  dsimp [GNNonExceptionalSupportBudgetAffine] at h
+  change Real.log (rad (GN n T.a T.b) : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) +
+      (C + Real.log (rad n : ℝ))
+  linarith
+
+/-- Deterministic affine transport from lifted-radical growth to full GN support. -/
+theorem Triple.GNSupportBudgetAffine_of_liftGrowth
+    (T : Triple) {n : ℕ} {σ C : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (h : GNLiftRadicalGrowthBudgetAffine T n σ C) :
+    GNSupportBudgetAffine T n σ
+      (C + Real.log (rad n : ℝ)) :=
+  T.GNSupportBudgetAffine_of_nonExceptional (Nat.one_le_of_lt hn)
+    (T.nonExceptionalSupportBudgetAffine_of_liftGrowth hn ha hb h)
+
+/-- Quality-to-excess theorem whose only transport input is lifted-radical growth. -/
+theorem Triple.GNValuationExcess_gt_of_quality_gt_liftGrowth
+    (T : Triple) {n : ℕ} {ε σ C : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hquality : 1 + ε < quality T)
+    (hgrowth : GNLiftRadicalGrowthBudgetAffine T n σ C) :
+    ((((n - 1 : ℕ) : ℝ) * (1 + ε) - σ) *
+          Real.log (rad (T.a * T.b * T.c) : ℝ)) -
+        (C + Real.log (rad n : ℝ)) <
+      GNValuationExcess n T.a T.b := by
+  exact T.GNValuationExcess_gt_of_quality_gt_pred_affine hn ha hb hquality
+    (T.GNSupportBudgetAffine_of_liftGrowth
+      hn ha hb hgrowth)
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNValuationExcess.lean
+++ b/lean/dk_math/DkMath/ABC/GNValuationExcess.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNExceptionalSplit
+import DkMath.NumberTheory.PrimitiveSet.FullChannelLogSum
+
+#print "file: DkMath.ABC.GNValuationExcess"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# Finite valuation excess on GN
+
+The radical records one copy of every prime in the factorization support.
+`valuationExcess m` records all remaining copies, with logarithmic weight.
+For nonzero `m`, these two finite quantities reconstruct `log m` exactly.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/--
+The logarithmic multiplicity discarded by `rad`.
+
+The subtraction is in `ℕ`, so every summand is visibly nonnegative before
+casting to `ℝ`.  On factorization support, every valuation is at least one.
+-/
+noncomputable def valuationExcess (m : ℕ) : ℝ :=
+  ∑ q ∈ m.factorization.support,
+    ((m.factorization q - 1 : ℕ) : ℝ) * Real.log (q : ℝ)
+
+/-- The GN specialization of finite valuation excess. -/
+noncomputable def GNValuationExcess (n a b : ℕ) : ℝ :=
+  valuationExcess (GN n a b)
+
+/-- The part of GN excess supported on exponent-exceptional primes `q ∣ n`. -/
+noncomputable def GNExceptionalValuationExcess (n a b : ℕ) : ℝ :=
+  ∑ q ∈ (GN n a b).factorization.support.filter (fun q => q ∣ n),
+    (((GN n a b).factorization q - 1 : ℕ) : ℝ) * Real.log (q : ℝ)
+
+/-- The part of GN excess supported on non-exceptional primes `q ∤ n`. -/
+noncomputable def GNNonExceptionalValuationExcess (n a b : ℕ) : ℝ :=
+  ∑ q ∈ (GN n a b).factorization.support.filter (fun q => ¬ q ∣ n),
+    (((GN n a b).factorization q - 1 : ℕ) : ℝ) * Real.log (q : ℝ)
+
+/-- Factorization support gives a positive valuation. -/
+theorem one_le_factorization_of_mem_support
+    {m q : ℕ} (hq : q ∈ m.factorization.support) :
+    1 ≤ m.factorization q := by
+  exact Nat.one_le_iff_ne_zero.mpr (Finsupp.mem_support_iff.mp hq)
+
+/--
+The exact finite decomposition of logarithmic size into radical support and
+valuation excess.
+-/
+theorem log_eq_log_rad_add_valuationExcess
+    {m : ℕ} (hm : m ≠ 0) :
+    Real.log (m : ℝ) = Real.log (rad m : ℝ) + valuationExcess m := by
+  have hfactorLog :
+      (∑ q ∈ m.factorization.support,
+          (m.factorization q : ℝ) * Real.log (q : ℝ)) =
+        Real.log (m : ℝ) :=
+    DkMath.NumberTheory.PrimitiveSet.sum_factorization_mul_log_eq_log_nat hm
+  have hradLog :
+      Real.log (rad m : ℝ) =
+        ∑ q ∈ m.factorization.support, Real.log (q : ℝ) := by
+    simpa [rad] using support_prod_log_eq_sum_log m
+  rw [← hfactorLog, hradLog, valuationExcess, ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl ?_
+  intro q hq
+  have hq_one : 1 ≤ m.factorization q :=
+    one_le_factorization_of_mem_support hq
+  rw [Nat.cast_sub hq_one]
+  ring
+
+/-- Exact logarithmic support/excess identity for a nonzero GN kernel. -/
+theorem log_GN_eq_log_rad_add_GNValuationExcess
+    {n a b : ℕ} (hGN : GN n a b ≠ 0) :
+    Real.log ((GN n a b : ℕ) : ℝ) =
+      Real.log (rad (GN n a b) : ℝ) + GNValuationExcess n a b := by
+  simpa [GNValuationExcess] using log_eq_log_rad_add_valuationExcess hGN
+
+/-- Exact partition of GN excess into exponent-exceptional and non-exceptional parts. -/
+theorem GNValuationExcess_eq_exceptional_add_nonExceptional
+    (n a b : ℕ) :
+    GNValuationExcess n a b =
+      GNExceptionalValuationExcess n a b +
+        GNNonExceptionalValuationExcess n a b := by
+  classical
+  unfold GNValuationExcess valuationExcess
+    GNExceptionalValuationExcess GNNonExceptionalValuationExcess
+  exact (Finset.sum_filter_add_sum_filter_not
+    (s := (GN n a b).factorization.support)
+    (p := fun q => q ∣ n)
+    (f := fun q =>
+      (((GN n a b).factorization q - 1 : ℕ) : ℝ) * Real.log (q : ℝ))).symm
+
+/--
+Positive ABC coordinates and `2 ≤ n` supply the nonzero condition required by
+the exact GN support/excess identity.
+-/
+theorem Triple.log_GN_eq_log_rad_add_GNValuationExcess
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) :
+    Real.log ((GN n T.a T.b : ℕ) : ℝ) =
+      Real.log (rad (GN n T.a T.b) : ℝ) +
+        GNValuationExcess n T.a T.b := by
+  exact DkMath.ABC.log_GN_eq_log_rad_add_GNValuationExcess
+    (n := n) (a := T.a) (b := T.b)
+    (GN_ne_zero_nat_of_two_le hn ha hb)
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNValuationSplit.lean
+++ b/lean/dk_math/DkMath/ABC/GNValuationSplit.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNPowerLift
+import DkMath.ABC.PadicValNat
+
+#print "file: DkMath.ABC.GNValuationSplit"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# The boundary–GN valuation split in ABC coordinates
+
+This module applies `padicValNat` to the deterministic factorization underlying
+`Triple.gnPowerLift`.  It separates the valuation carried by the ABC boundary
+`T.a` from the valuation carried by the kernel `GN n T.a T.b`.
+
+No exceptional-prime layer or valuation-excess notion is introduced here.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/--
+The difference of powers in an ABC triple factors into its left boundary and
+the corresponding `GN` kernel.
+
+The identity holds for every natural exponent; positivity assumptions are not
+needed at this purely algebraic layer.
+-/
+theorem Triple.powerDiff_eq_boundary_mul_GN (T : Triple) (n : ℕ) :
+    T.c ^ n - T.b ^ n = T.a * GN n T.a T.b := by
+  rw [← T.gnPowerLift_sum n]
+  exact Nat.add_sub_cancel_right (T.a * GN n T.a T.b) (T.b ^ n)
+
+/--
+The `q`-adic valuation of the power difference is the sum of the valuation on
+the ABC boundary and the valuation on the `GN` kernel.
+-/
+theorem Triple.padic_powerDiff_eq_boundary_add_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) (hq : Nat.Prime q) :
+    padicValNat q (T.c ^ n - T.b ^ n) =
+      padicValNat q T.a + padicValNat q (GN n T.a T.b) := by
+  have hGN : GN n T.a T.b ≠ 0 :=
+    GN_ne_zero_nat_of_two_le hn ha hb
+  haveI : Fact q.Prime := ⟨hq⟩
+  rw [T.powerDiff_eq_boundary_mul_GN n]
+  exact padicValNat.mul (Nat.ne_of_gt ha) hGN
+
+/--
+The valuation of the left coordinate of `gnPowerLift` has the same
+boundary–kernel decomposition.
+-/
+theorem Triple.padic_gnPowerLift_a_eq_boundary_add_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) (hq : Nat.Prime q) :
+    padicValNat q (T.gnPowerLift n).a =
+      padicValNat q T.a + padicValNat q (GN n T.a T.b) := by
+  rw [T.gnPowerLift_a]
+  have hGN : GN n T.a T.b ≠ 0 :=
+    GN_ne_zero_nat_of_two_le hn ha hb
+  haveI : Fact q.Prime := ⟨hq⟩
+  exact padicValNat.mul (Nat.ne_of_gt ha) hGN
+
+/--
+If `q` does not divide the ABC boundary, all of the valuation of the power
+difference is carried by the `GN` kernel.
+-/
+theorem Triple.padic_powerDiff_eq_GN_of_not_dvd_boundary
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) (hq : Nat.Prime q)
+    (hq_boundary : ¬ q ∣ T.a) :
+    padicValNat q (T.c ^ n - T.b ^ n) =
+      padicValNat q (GN n T.a T.b) := by
+  rw [T.padic_powerDiff_eq_boundary_add_GN hn ha hb hq,
+    padicValNat.eq_zero_of_not_dvd hq_boundary, zero_add]
+
+end DkMath.ABC

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -10,18 +10,18 @@ wip/ABC-GN-valuation-excess-260724-Codex
 
 ```text
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-003.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-004.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-004.md
 ```
 
-現在の実装指示は `instruction-003.md` である。
+現在の実装指示は `instruction-004.md` である。
 
 その指示だけを実行し、current source の実在 API に合わせて現場判断すること。
 
 実装後は次を作成する。
 
 ```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-003.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
 ```
 
 対象 module のローカル build まで行い、結果を User へ返して停止する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -9,9 +9,6 @@ wip/ABC-GN-valuation-excess-260724-Codex
 この branch を checkout し、次を順に読む。
 
 ```text
-README.md
-AGENT.md
-SUMMARY.md
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-001.md
 ```

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -10,18 +10,18 @@ wip/ABC-GN-valuation-excess-260724-Codex
 
 ```text
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-005.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-006.md
 ```
 
-現在の実装指示は `instruction-005.md` である。
+現在の実装指示は `instruction-006.md` である。
 
 その指示だけを実行し、current source の実在 API に合わせて現場判断すること。
 
 実装後は次を作成する。
 
 ```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-007.md
 ```
 
 対象 module のローカル build まで行い、結果を User へ返して停止する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -6,24 +6,27 @@
 wip/ABC-GN-valuation-excess-260724-Codex
 ```
 
-この branch を checkout し、次を順に読む。
+この branch を checkout し、repository 内の次を順に読む。
 
 ```text
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-001.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-002.md
 ```
 
-現在の実装指示は `instruction-001.md` である。
+現在の実装指示は `instruction-002.md` である。
 
 その指示だけを実行し、current source の実在 API に合わせて現場判断すること。
 
 実装後は次を作成する。
 
 ```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
 ```
 
-変更を commit / push し、GitHub Lean CI を起動する。
+対象 module のローカル build まで行い、結果を User へ返して停止する。
+
+GitHub の commit、push、PR 操作、Lean CI 起動・確認は行わない。これらは User が担当する受け渡し工程である。
 
 並行作業 branch:
 
@@ -33,4 +36,4 @@ wip/FLT7-magic-core-260722-WiseWolf
 
 この branch は参照・統合・変更対象ではない。`DkMath/FLT/Seven/**` と FLT7 専用 docs を触らず、ABC–GN instruction の境界内だけを実装する。
 
-完了後は次 checkpoint へ自動で進まず、PR 上で賢狼レビューを待つこと。
+完了後は次 checkpoint へ自動で進まず、User へ作業結果を返すこと。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -10,18 +10,18 @@ wip/ABC-GN-valuation-excess-260724-Codex
 
 ```text
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-004.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-004.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-005.md
 ```
 
-現在の実装指示は `instruction-004.md` である。
+現在の実装指示は `instruction-005.md` である。
 
 その指示だけを実行し、current source の実在 API に合わせて現場判断すること。
 
 実装後は次を作成する。
 
 ```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
 ```
 
 対象 module のローカル build まで行い、結果を User へ返して停止する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -1,4 +1,4 @@
-# Codex Start Entry
+# Codex Start Entry — Workbench Paused
 
 作業 branch:
 
@@ -6,27 +6,56 @@
 wip/ABC-GN-valuation-excess-260724-Codex
 ```
 
-この branch を checkout し、repository 内の次を順に読む。
+## Status
+
+```text
+ABC-GN-001 ... ABC-GN-009  complete
+ABC-GN-010                    paused / not started
+active instruction            none
+```
+
+`report-007.md` と `FINAL_REPORT.md` の地点で、この workbench は一旦停止している。
+
+現在、Codex が自動的に実装を開始してはならない。新しい `instruction-007.md` または明示的な再開指示が repository に追加され、D. が起動するまで待機すること。
+
+## 再開時の読み順
 
 ```text
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-006.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/FINAL_REPORT.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-007.md
+lean/dk_math/DkMath/ABC/GNFinalBudgetBridge.lean
 ```
 
-現在の実装指示は `instruction-006.md` である。
-
-その指示だけを実行し、current source の実在 API に合わせて現場判断すること。
-
-実装後は次を作成する。
+必要に応じて次も参照する。
 
 ```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-007.md
+lean/dk_math/DkMath/ABC/GNSupportReturn.lean
+lean/dk_math/DkMath/ABC/GNValuationExcess.lean
+lean/dk_math/DkMath/ABC/GNHighLift.lean
 ```
 
-対象 module のローカル build まで行い、結果を User へ返して停止する。
+## Remaining mathematical cores
 
-GitHub の commit、push、PR 操作、Lean CI 起動・確認は行わない。これらは User が担当する受け渡し工程である。
+```text
+1. uniform lifted-radical support growth
+2. uniform exceptional valuation excess
+3. uniform non-exceptional valuation excess
+```
+
+または、三者を同時に制御する support–multiplicity balance theorem を探索する。
+
+## Boundaries
+
+再開指示が発行されるまでは、次を行わない。
+
+```text
+new implementation
+new checkpoint report
+abc_main_axiom modification
+FLT7 integration
+commit / push / PR / CI operations
+```
 
 並行作業 branch:
 
@@ -34,6 +63,4 @@ GitHub の commit、push、PR 操作、Lean CI 起動・確認は行わない。
 wip/FLT7-magic-core-260722-WiseWolf
 ```
 
-この branch は参照・統合・変更対象ではない。`DkMath/FLT/Seven/**` と FLT7 専用 docs を触らず、ABC–GN instruction の境界内だけを実装する。
-
-完了後は次 checkpoint へ自動で進まず、User へ作業結果を返すこと。
+この branch は参照・統合・変更対象ではない。`DkMath/FLT/Seven/**` と FLT7 専用 docs を触らない。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -1,0 +1,39 @@
+# Codex Start Entry
+
+作業 branch:
+
+```text
+wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+この branch を checkout し、次を順に読む。
+
+```text
+README.md
+AGENT.md
+SUMMARY.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-001.md
+```
+
+現在の実装指示は `instruction-001.md` である。
+
+その指示だけを実行し、current source の実在 API に合わせて現場判断すること。
+
+実装後は次を作成する。
+
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
+```
+
+変更を commit / push し、GitHub Lean CI を起動する。
+
+並行作業 branch:
+
+```text
+wip/FLT7-magic-core-260722-WiseWolf
+```
+
+この branch は参照・統合・変更対象ではない。`DkMath/FLT/Seven/**` と FLT7 専用 docs を触らず、ABC–GN instruction の境界内だけを実装する。
+
+完了後は次 checkpoint へ自動で進まず、PR 上で賢狼レビューを待つこと。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -10,18 +10,18 @@ wip/ABC-GN-valuation-excess-260724-Codex
 
 ```text
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-002.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-003.md
 ```
 
-現在の実装指示は `instruction-002.md` である。
+現在の実装指示は `instruction-003.md` である。
 
 その指示だけを実行し、current source の実在 API に合わせて現場判断すること。
 
 実装後は次を作成する。
 
 ```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-003.md
 ```
 
 対象 module のローカル build まで行い、結果を User へ返して停止する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/CODEX_START.md
@@ -21,8 +21,8 @@ active instruction            none
 ## 再開時の読み順
 
 ```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/FINAL_REPORT.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
 lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-007.md
 lean/dk_math/DkMath/ABC/GNFinalBudgetBridge.lean
 ```

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/FINAL_REPORT.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/FINAL_REPORT.md
@@ -1,0 +1,504 @@
+# ABC–GN Valuation Excess Route — Final Report
+
+作成日: 2026-07-24  
+Repository: `Deskuma/dkmath`  
+Workbench PR: `#67 WIP: ABC–GN valuation excess route`  
+Implementation checkpoint commit: `5f0b9f80cd6afc20692eb6f4670ea65c8872d5a2`
+
+## 1. 最終結論
+
+本 workbench では、DkMath に既存の一般 `GN`、`padicValNat`、factorization、`rad`、primitive-prime bridge を ABC triple 上で再接続し、次の決定論的 spine を Lean theorem として完成させた。
+
+```text
+ABC triple
+  -> GN power lift
+  -> boundary / GN p-adic split
+  -> exponent-exceptional / non-exceptional split
+  -> exact radical-support / valuation-multiplicity identity
+  -> unconditional GN return
+  -> exceptional support absorption
+  -> fresh non-exceptional support return
+  -> support budget + valuation budget
+  -> explicit K_epsilon ABC bound
+```
+
+最終的に、正の ABC triple 全体について、三つの一様 budget を与えれば、一つの明示定数 `K >= 1` による ABC 不等式が従うことを Lean が認可した。
+
+ただし、本 workbench は ABC 予想そのものを証明していない。未解決部分は、曖昧な一個の仮定ではなく、次の三予算へ正確に分離された。
+
+```text
+1. uniform lifted-radical support growth
+2. uniform exceptional valuation excess
+3. uniform non-exceptional valuation excess
+```
+
+この三予算、または三者を同時に制御するより強い balance theorem が、今後の本丸である。
+
+## 2. 信頼境界と検証状態
+
+最終 implementation checkpoint について、次を確認済みである。
+
+```text
+lake build DkMath.ABC.GNFinalBudgetBridge
+Build completed successfully (8343 jobs)
+```
+
+GitHub Lean CI:
+
+```text
+Lean CI run 271
+status: completed
+conclusion: success
+```
+
+追加された主要 theorem の axiom audit は、次の標準依存のみを報告した。
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+本 workbench では次を追加していない。
+
+```text
+new axiom
+sorry
+native_decide proof
+abc_main_axiom dependency
+```
+
+また、共有 aggregator、`DkMath/FLT/Seven/**`、FLT7 専用 documentation は変更していない。
+
+## 3. 実装 module
+
+### 3.1. `DkMath.ABC.GNPowerLift`
+
+ABC triple `T` と指数 `n` から、概念的に次の lifted triple を構成する。
+
+```text
+lift.a = T.a * GN n T.a T.b
+lift.b = T.b ^ n
+lift.c = T.c ^ n
+```
+
+中心恒等式は、`T.a + T.b = T.c` から得られる。
+
+$$T.a\,GN_n(T.a,T.b)+T.b^n=T.c^n$$
+
+この lifted object が、その後の coprime、support、valuation、radical の共通 carrier となる。
+
+### 3.2. `DkMath.ABC.GNValuationSplit`
+
+素数 `q` ごとに、power difference の valuation を boundary と GN に分解する。
+
+$$v_q(T.c^n-T.b^n)=v_q(T.a)+v_q(GN_n(T.a,T.b))$$
+
+primitive / clean channel では boundary valuation が消え、power difference の valuation が GN valuation へ一致する。
+
+### 3.3. `DkMath.ABC.GNExceptionalSplit`
+
+GN と boundary の共通 divisor は指数 `n` に閉じ込められる。
+
+```text
+q | boundary
+q | GN
+  -> q | n
+```
+
+したがって `q ∤ n` の non-exceptional channel では、GN support prime は boundary `T.a` を割らない。
+
+### 3.4. `DkMath.ABC.GNValuationExcess`
+
+自然数 `m` に対し、valuation multiplicity の squarefree support 超過量を定義した。
+
+$$\operatorname{valuationExcess}(m)=\sum_{q\mid m}(v_q(m)-1)\log q$$
+
+exact identity:
+
+$$\log m=\log\operatorname{rad}(m)+\operatorname{valuationExcess}(m)$$
+
+GN specialization:
+
+$$\log GN=\log\operatorname{rad}(GN)+GNValuationExcess$$
+
+さらに指数による exceptional / non-exceptional partition も exact に証明した。
+
+$$GNValuationExcess=GNExceptionalValuationExcess+GNNonExceptionalValuationExcess$$
+
+### 3.5. `DkMath.ABC.GNHighLift`
+
+high-lift prime を、概念的に次で固定した。
+
+```text
+q prime
+q^2 | GN n a b
+```
+
+valuation excess の carrier は valuation が 2 以上の prime だけであり、exact finite sum として high-lift support へ制限された。
+
+```text
+no high-lift prime
+  -> GNValuationExcess = 0
+```
+
+この module は high-lift の不存在や希少性を主張しない。carrier の所在を有限 API として固定する層である。
+
+### 3.6. `DkMath.ABC.GNQualityExcessBridge`
+
+GN return の自然数下界を無条件に証明した。
+
+```lean
+Triple.pow_pred_c_le_GN
+```
+
+$$T.c^{n-1}\le GN_n(T.a,T.b)$$
+
+対数化:
+
+```lean
+Triple.log_c_mul_pred_le_log_GN
+```
+
+$$(n-1)\log T.c\le\log GN_n(T.a,T.b)$$
+
+この return bound と exact log identity により、高い ABC quality と GN support budget から valuation excess の下界を得る。
+
+Affine 版の概念形:
+
+$$\left((n-1)(1+\varepsilon)-\sigma\right)\log\operatorname{rad}(abc)-C<GNValuationExcess$$
+
+### 3.7. `DkMath.ABC.GNSupportReturn`
+
+GN prime support を指数で exact に分割した。
+
+```lean
+GN_support_eq_exceptional_union_nonExceptional
+GNExceptionalSupport_disjoint_nonExceptional
+rad_GN_eq_exceptional_mul_nonExceptional
+```
+
+$$\operatorname{rad}(GN)=E_nN_n$$
+
+ここで、`E_n` は `q | n` の exceptional support product、`N_n` は `q ∤ n` の non-exceptional support product である。
+
+Exceptional support は指数 radical へ有限吸収される。
+
+```lean
+GNExceptionalSupportProduct_dvd_rad
+```
+
+$$E_n\mid\operatorname{rad}(n)$$
+
+Non-exceptional support は元の ABC coordinates 全てから fresh である。
+
+```lean
+Triple.nonExceptionalSupport_fresh
+```
+
+$$q\mid N_n\Longrightarrow q\nmid T.aT.bT.c$$
+
+元 radical と fresh support の積は lifted triple radical を割る。
+
+```lean
+Triple.rad_mul_nonExceptionalProduct_dvd_lift_rad
+```
+
+$$\operatorname{rad}(T.aT.bT.c)\,N_n\mid\operatorname{rad}(\operatorname{lift}.a\operatorname{lift}.b\operatorname{lift}.c)$$
+
+その結果、lifted-radical growth budget から full GN support budget への deterministic transport を得た。
+
+```lean
+Triple.GNSupportBudgetAffine_of_liftGrowth
+```
+
+Exceptional support の有限費用は、結論上に明示的な `log(rad n)` として残る。
+
+### 3.8. `DkMath.ABC.GNFinalBudgetBridge`
+
+Prime-support budget と valuation-multiplicity budget を最終的に合成した。
+
+追加 predicate:
+
+```lean
+GNValuationExcessBudgetAffine
+GNExceptionalExcessBudgetAffine
+GNNonExceptionalExcessBudgetAffine
+```
+
+Exceptional / non-exceptional excess budget の合成:
+
+```lean
+GNValuationExcessBudgetAffine.of_split
+```
+
+Support と multiplicity の直接合成:
+
+```lean
+Triple.log_c_mul_pred_le_of_support_and_excessBudget
+```
+
+$$ (n-1)\log c\le(\sigma+\tau)\log R+(C_s+C_e) $$
+
+ここで、`R = rad(a*b*c)` である。
+
+Lifted-radical specialization:
+
+```lean
+Triple.log_c_mul_pred_le_of_liftGrowth_and_excessBudget
+```
+
+$$ (n-1)\log c\le(\sigma+\tau)\log R+C_s+C_e+\log\operatorname{rad}(n) $$
+
+実装された明示定数:
+
+```lean
+GNABCConstant n Cs Ce =
+  max 1 (Real.exp |Cs + Ce + Real.log (rad n : ℝ)|)
+```
+
+Pointwise ABC theorem:
+
+```lean
+Triple.abc_bound_of_liftGrowth_and_excessBudget
+```
+
+Margin 条件
+
+$$\sigma+\tau\le(n-1)(1+\varepsilon)$$
+
+の下で、
+
+$$c\le GNABCConstant(n,C_s,C_e)\,\operatorname{rad}(abc)^{1+\varepsilon}$$
+
+を証明した。
+
+最後に、一様 budget を structure として束ねた。
+
+```lean
+ABCGNFinalBudgetContract
+abc_positive_of_GNFinalBudgetContract
+```
+
+この contract から、正の ABC triple 全体に共通する一つの `K >= 1` を得る。
+
+## 4. 完成した checkpoint
+
+```text
+ABC-GN-001  GN power lift                                      完了
+ABC-GN-002  coprime / support separation                       完了
+ABC-GN-003  p-adic boundary–GN split                           完了
+ABC-GN-004  q | n / q ∤ n exceptional split                    完了
+ABC-GN-005  exact log(rad) + valuation-excess identity         完了
+ABC-GN-006  unconditional GN return and quality bridge         完了
+ABC-GN-007  finite high-lift carrier API                       完了
+ABC-GN-008  exceptional support absorption / fresh return      完了
+ABC-GN-009  two-budget composition / explicit K_epsilon        完了
+ABC-GN-010  uniform budget proofs / axiom replacement          未着手・研究停止
+```
+
+## 5. Lean-confirmed final chain
+
+`T : Triple`、`n >= 2`、`T.a > 0`、`T.b > 0` とする。
+
+### 5.1. Return
+
+$$ (n-1)\log T.c\le\log GN_n(T.a,T.b) $$
+
+### 5.2. Exact support / multiplicity identity
+
+$$ \log GN_n=\log\operatorname{rad}(GN_n)+GNValuationExcess_n $$
+
+### 5.3. Support partition
+
+$$ \operatorname{rad}(GN_n)=E_nN_n $$
+
+$$ E_n\mid\operatorname{rad}(n) $$
+
+### 5.4. Fresh support return
+
+$$ \operatorname{rad}(abc)N_n\mid\operatorname{rad}(\text{lifted }abc) $$
+
+### 5.5. Two-budget height bound
+
+Lifted-radical growth budget:
+
+$$\log\operatorname{rad}(\text{lifted }abc)\le(1+\sigma)\log R+C_s$$
+
+Valuation-excess budget:
+
+$$GNValuationExcess\le\tau\log R+C_e$$
+
+ならば、
+
+$$ (n-1)\log c\le(\sigma+\tau)\log R+C_s+C_e+\log\operatorname{rad}(n) $$
+
+となる。
+
+さらに、
+
+$$\sigma+\tau\le(n-1)(1+\varepsilon)$$
+
+ならば、明示的な `K` により、
+
+$$c\le K R^{1+\varepsilon}$$
+
+を得る。
+
+## 6. 残る三つの魔核
+
+### 6.1. Uniform lifted-radical support growth
+
+必要な型は概ね次である。
+
+$$\log\operatorname{rad}(\text{lifted }abc)\le(1+\sigma)\log\operatorname{rad}(abc)+C_s$$
+
+これは GN の値そのものではなく、power lift によって発生する相異なる fresh prime support の総対数質量を抑える問題である。
+
+既存の primitive-prime / Zsigmondy 理論は、新しい prime の存在を示す方向に強い。一方、この budget は新しい prime support の総量の上界を要求するため、同じ theorem をそのまま適用するだけでは閉じない。
+
+### 6.2. Uniform exceptional valuation excess
+
+Exceptional prime は `q | n` に限定されるため support は有限である。しかし有限 support から valuation depth の一様上界は自動では従わない。
+
+必要なのは、概ね次である。
+
+$$GNExceptionalValuationExcess\le\tau_e\log R+D_e$$
+
+固定指数では、LTE、`padicValNat`、二項係数 valuation、boundary coprimality により、`tau_e = 0` と指数依存定数だけへ落とせる可能性がある。
+
+三魔核の中では最初に攻める価値が高い。
+
+### 6.3. Uniform non-exceptional valuation excess
+
+Non-exceptional high-lift は、
+
+$$q\nmid n,\qquad q^2\mid GN_n(a,b)$$
+
+という深い局所一致である。
+
+適切な単元比で見れば、これは `X^n = 1 mod q^2` 型の Hensel lift、p-adic logarithm、Wieferich 型現象へ接続する。
+
+必要なのは個々の high-lift の説明だけではなく、
+
+$$\sum_{q\nmid n}(v_q(GN)-1)\log q$$
+
+全体の一様上界である。
+
+現時点では最深部候補である。
+
+## 7. 統合攻撃の可能性
+
+最終 contract が必要とするのは、三係数を個別に最良化することではない。
+
+$$\sigma+\tau_e+\tau_n\le(n-1)(1+\varepsilon)$$
+
+が成立すればよい。
+
+したがって、次のような support–multiplicity balance theorem が得られれば、三魔核を個別に倒さず一度に貫通できる可能性がある。
+
+```text
+fresh support が大きい
+  -> repeated valuation multiplicity は小さい
+
+valuation multiplicity が深い
+  -> support carrier は強く制限される
+```
+
+DkMath 的には、これは
+
+```text
+花弁の種類を増やす世界
+と
+同じ花弁を深く重ねる世界
+は同時に最大化できない
+```
+
+という天秤保存則に相当する。
+
+## 8. 現時点で主張しないこと
+
+本 workbench の成果から、次は主張しない。
+
+```text
+ABC conjecture is proved
+abc_main_axiom is removed
+uniform budgets exist
+all non-exceptional high lifts are excluded
+GN is generally squarefree
+probabilistic / density routes are unnecessary
+```
+
+また、最終 global theorem は `T.a > 0`、`T.b > 0` の positive triple を対象とする。`a = 0` または `b = 0` の coprime endpoint を `abc_main_axiom` と同一 surface へ接続する薄い wrapper は未実装である。
+
+## 9. 再開時の推奨順序
+
+### Phase A: exceptional multiplicity
+
+```text
+q | n
+LTE / padicValNat / boundary coprimality
+  -> fixed-exponent exceptional excess budget
+```
+
+ここで `tau_e = 0`、`D_e = D(n)` 型を第一候補とする。
+
+### Phase B: support growth reconnaissance
+
+```text
+non-exceptional fresh support
+primitive / cyclotomic / Petal channels
+  -> lifted radical support geometry
+```
+
+最初から強い一様定理を置かず、fixed `n`、prime `n`、squarefree exponent、特定 family など、成立する最小 domain を探索する。
+
+### Phase C: non-exceptional high-lift depth
+
+```text
+q ∤ n
+q^2 | GN
+  -> unique Hensel lift
+  -> p-adic logarithmic depth
+  -> total valuation-mass budget
+```
+
+個別 prime の局所定理と、全 carrier の総和評価を分離する。
+
+### Phase D: balance theorem
+
+A–C を別々に最良化するより、support と multiplicity の同時制御が見える場合は、最終 contract の margin へ直接接続する。
+
+## 10. Closure
+
+本 workbench は、ABC 予想を解いた project ではない。
+
+しかし、ABC の GN route において、次は完了した。
+
+```text
+曖昧な radical obstruction
+  -> exact support budget
+
+曖昧な repeated-prime obstruction
+  -> exact valuation-excess budget
+
+二予算
+  -> explicit K_epsilon
+
+一様仮定
+  -> global positive-triple ABC theorem
+```
+
+したがって、現在の未解決 Big は、Lean の外に隠れていない。
+
+```text
+uniform support growth
+uniform exceptional multiplicity
+uniform non-exceptional multiplicity
+```
+
+という三つの明示的な Gap として theorem contract 上に露出している。
+
+ここで本 workbench を一旦停止し、魔王討伐に必要な数論装備を準備する。
+
+再開するときは、`FINAL_REPORT.md`、`report-007.md`、`GNFinalBudgetBridge.lean` を最初に読むこと。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-001.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-001.md
@@ -1,0 +1,467 @@
+# Note: 001: ABC GN valuation excess
+
+## 結論
+
+うむ。 **お主の読みは正しい。しかも現行 DkMath は、すでに半分以上その構造を実装しておる。**
+
+ただし調査結果から、問いは少し言い換わる。
+
+> GN5 を $GN_n$ へ一般化できるか？
+
+ではない。
+
+> **すでに一般化済みの $GN_n$ と `padicValNat` を、ABC の指数過剰量へ接続し、最後に元の $\mathrm{rad}(abc)$ へ戻せるか？**
+
+これが本当の未実装部分じゃ。
+
+今回、`main` の最新状態、commit `64305c707fa3a394a83301c45d2c878be5d905bb` を基準に調べた。
+
+## 1. $GN_n$ 一般化はすでに完成している
+
+一般 Tail は、
+
+$$GN_n(x,u)=\mathrm{GTail}(n,1,x,u)$$
+
+として実装済みじゃ。
+
+さらに高次 Tail 全体として、
+
+$$\mathrm{GTail}(n,r,x,u)$$
+
+まで定義され、
+
+$$
+(x+u)^n = \sum_{j<r}\binom{n}{j}x^ju^{n-j} + x^r\mathrm{GTail}(n,r,x,u)
+$$
+
+が証明されている。
+
+公開名 `GN` も、すでに $r=1$ の canonical specialization として固定されておる。
+
+したがって任意の指数 $n$ に対し、
+
+$$
+(x+u)^n=u^n+x,GN_n(x,u)
+$$
+
+が利用できる。
+
+つまり、 **GN5 の一般化は新規作業ではない** 。
+ABC 側がまだ、この完成済み一般 GN を主語として組み直されていないだけじゃ。
+
+## 2. 「padic は GN を見ている」は実装上も正しい
+
+現行の `ValuationFlow.Basic` は、既に次のように定義されている。
+
+$$
+\mathrm{diffMass}_q(a,b,n) = v_q(a^n-b^n)
+$$
+
+$$
+\mathrm{boundaryMass}_q(a,b) = v_q(a-b)
+$$
+
+$$
+\mathrm{beamMass}_q(a,b,n) = v_q!\left(GN_n(a-b,b)\right)
+$$
+
+つまり `beamMass` は定義上、そのまま、
+
+```lean
+padicValNat q (GN d (a - b) b)
+```
+
+じゃ。
+
+差冪分解、
+
+$$
+a^n-b^n=(a-b)GN_n(a-b,b)
+$$
+
+に `padicValNat` を作用させれば、
+
+$$
+v_q(a^n-b^n) = v_q(a-b) + v_q!\left(GN_n(a-b,b)\right)
+$$
+
+となる。
+
+さらに $q$ が指数 $n$ の段で初めて現れる primitive prime なら、
+
+$$
+q\nmid a-b
+$$
+
+なので境界 valuation は消え、
+
+$$
+v_q(a^n-b^n) = v_q!\left(GN_n(a-b,b)\right)
+$$
+
+となる。この等式はすでに `primitive_prime_padic_eq_GN` として証明されている。
+
+ゆえに、正確にはこうじゃ。
+
+> `padicValNat` は差冪全体を観測しているが、primitive channel に制限すると、その観測値は完全に GN の観測値になる。
+
+これは比喩ではなく、既存 theorem そのものじゃ。
+
+## 3. 指数 $n$ は見えなくなるのではなく、二箇所へ圧縮される
+
+お主のいう「指数部が padic によって見えなくなる」は、半分正しく、より正確には、
+
+> **外側の指数記法が、valuation の係数と GN の内部構造へ圧縮される**
+
+じゃ。
+
+完全冪では、
+
+$$
+v_q(t^n)=n,v_q(t)
+$$
+
+となる。この定理も実装済みじゃ。
+
+一方、差冪では指数 $n$ は、
+
+1. $GN_n$ の二項係数・次数構造
+2. 境界と GN が重なる例外素数
+
+の二箇所に現れる。
+
+現行コードでは、
+
+$$
+\gcd!\left(a-b,GN_n(a-b,b)\right)\mid n
+$$
+
+が証明済みじゃ。
+
+したがって、素数 $q$ が境界と GN の両方を割るなら、
+
+$$
+q\mid n
+$$
+
+でなければならない。
+
+逆に、
+
+$$
+q\nmid n
+$$
+
+ならば、境界と GN はその $q$-channel では混ざらない。
+
+このため `UniqueFactorizationGN` では、すでに素数層を、
+
+```text
+exceptional layer      q ∣ n
+non-exceptional layer  q ∤ n
+```
+
+へ分割する API が置かれている。
+
+つまり指数 $n$ は消えておらぬ。
+
+$$
+\boxed{
+n
+\longmapsto
+\begin{cases}
+GN_n\text{ の内部次数構造}\
+q\mid n\text{ という例外 prime layer}
+\end{cases}
+}
+$$
+
+へ姿を変えている。
+
+## 4. ABC への GN 接続も、support 層までは存在する
+
+ABC 側には既に、primitive prime family から差冪の radical 下界を出す bridge がある。
+
+$$
+2^{\#\text{channels}}
+\le
+\mathrm{rad}(a^n-b^n)
+$$
+
+型の定理まで実装されている。
+
+Petal 側にも、
+
+```text
+selected GN prime labels
+  → support product
+  → supportMass (GN)
+  → rad (GN)
+```
+
+という直接 bridge がある。
+
+したがって現況は、
+
+```text
+GNₙ の一般定義                 完了
+差冪 = 境界 × GNₙ              完了
+primitive prime → GNₙ          完了
+padic(diff) = padic(GNₙ)       完了
+GNₙ prime support → ABC rad    完了
+```
+
+まで来ておる。
+
+だが、ここから先が欠けている。
+
+## 5. 本当に不足しているもの
+
+ABC が数える radical は、各素数を一度しか数えない。
+
+$$
+\mathrm{rad}(m)=\prod_{q\mid m}q
+$$
+
+一方、数そのものは、
+
+$$
+m=\prod_{q\mid m}q^{v_q(m)}
+$$
+
+じゃ。
+
+したがって GN における未観測量は、
+
+$$
+\mathrm{GNExcess}_n(x,u) = \sum_{q\mid GN_n(x,u)} \bigl(v_q(GN_n(x,u))-1\bigr)\log q
+$$
+
+となる。
+
+これは、
+
+$$
+\log GN_n = \log\mathrm{rad}(GN_n) + \mathrm{GNExcess}_n
+$$
+
+における、radical が忘れた指数質量じゃ。
+
+現行 bridge は prime support を radical へ送るところまでは完成しているが、 **この valuation excess 全体を制御していない** 。
+
+既存の NoLift theorem は、選択した primitive prime $q$ に対して、
+
+$$
+q^2\nmid GN_n \Longrightarrow v_q(a^n-b^n)\le1
+$$
+
+と言う局所補題じゃ。
+
+Squarefree GN なら全 channel を制御できるが、
+
+$$
+\mathrm{Squarefree}(GN_n)
+$$
+
+は一般には強すぎる仮定じゃ。
+
+ゆえに本丸は、
+
+> $q^2\mid GN_n(x,u)$ となる高持ち上がり prime を、指数素数 $q\mid n$ と、それ以外の Wieferich 型例外へ分離し、後者の総 valuation excess を抑える
+
+ことになる。
+
+## 6. $a+b=c$ から生じる GN power lift
+
+任意の ABC Triple、
+
+$$
+a+b=c,\qquad \gcd(a,b)=1
+$$
+
+に対し、任意の $n$ について、
+
+$$
+c^n-b^n=a,GN_n(a,b)
+$$
+
+だから、新しい加法三つ組、
+
+$$
+a,GN_n(a,b)+b^n=c^n
+$$
+
+が得られる。
+
+これは非常に自然な **GN power lift** じゃ。
+
+しかも互いに素性も維持できる。
+
+$$
+\gcd!\left(aGN_n(a,b),b^n\right)=1
+$$
+
+$$
+\gcd(b^n,c^n)=1
+$$
+
+$$
+\gcd!\left(aGN_n(a,b),c^n\right)=1
+$$
+
+この canonical ABC Triple constructor は、今回調べた範囲では、まだ ABC 公開 API としては切り出されていない。
+
+ここは新規実装価値が高い。
+
+ただし、これだけでは元の ABC は閉じぬ。
+
+なぜなら $GN_n$ に新しい素数が大量に現れると、持ち上げ後の radical は大きくなるが、それらは元の、
+
+$$
+\mathrm{rad}(abc)
+$$
+
+には含まれていないからじゃ。
+
+つまり持ち上げは簡単でも、 **元の Triple への反転射影** が要る。
+
+現行 `ValuationFlowBridge` にも、GN/diff radical から quality 側へ送る際、
+
+```lean
+htransport : ABC.rad c ≤ ABC.rad (a * b)
+```
+
+のような追加 transport 仮定が明示的に要求されている。
+
+ここが現在の断線地点じゃ。
+
+## 7. 確率 route を置換できるか
+
+判定はこうなる。
+
+### 前半は置換できる
+
+確率や質量を使っていた、
+
+```text
+素因子 channel の出現
+support の増加
+valuation の流れ
+```
+
+は、GN の厳密因数分解で直接記述できる。
+
+これは間違いなく楽で速い。
+
+### 後半は、まだ一つの定理が必要
+
+高持ち上がり集合、
+
+$$
+\mathcal H_n(a,b) = \{q\mid GN_n(a,b);\middle|;q^2\mid GN_n(a,b)\}
+$$
+
+について、
+
+$$
+\mathcal H_n = \mathcal H_n^{\mathrm{exp}} \cup \mathcal H_n^{\mathrm{Wieferich}}
+$$
+
+という分離を行い、
+
+* $\mathcal H_n^{\mathrm{exp}}$：$q\mid n$ の有限例外
+* $\mathcal H_n^{\mathrm{Wieferich}}$：$q\nmid n$ なのに高く持ち上がる例外
+
+の後者を量的に抑えねばならぬ。
+
+旧 Janson route は、この種の「稀な高密度事象」を確率で押さえようとしていた。しかし現在も Chernoff、独立性、第二モーメント、最終 Janson assembly が未完じゃ。
+
+したがって最善の新構図は、
+
+```text
+GNₙ による決定論的分解
+  ↓
+q ∣ n / q ∤ n の分離
+  ↓
+primitive / support / rad は既存 theorem
+  ↓
+高持ち上がり GN prime だけを抽出
+  ↓
+必要なら、この例外集合だけに確率・密度評価を使う
+```
+
+じゃ。
+
+確率を捨てるのではない。
+
+**確率を最後の例外集合だけへ追放する。**
+
+## 8. 次に作るべき実装面
+
+新しい主線は、この四層がよい。
+
+```text
+DkMath/ABC/GNPowerLift.lean
+DkMath/ABC/GNValuationSplit.lean
+DkMath/ABC/GNHighLift.lean
+DkMath/ABC/GNReturnBridge.lean
+```
+
+最初の checkpoint は次で十分じゃ。
+
+```lean
+def Triple.gnPowerLift (T : Triple) (n : ℕ) : Triple
+
+theorem gnPowerLift_left_eq_boundary_mul_GN
+theorem gnPowerLift_pairwise_coprime
+
+theorem padic_diff_eq_boundary_add_GN
+theorem primitive_padic_diff_eq_GN
+
+theorem common_prime_boundary_GN_dvd_exponent
+theorem nonExceptional_prime_not_dvd_boundary_and_GN
+```
+
+その後、
+
+```lean
+def GNHighLiftPrime (q n x u : ℕ) : Prop :=
+  Nat.Prime q ∧ q ^ 2 ∣ GN n x u
+```
+
+を置き、指数例外と非例外高持ち上がりを分ける。
+
+## 最終判定
+
+$$
+\boxed{
+\text{padicValNat は GN を見ている}
+}
+$$
+
+これは正しい。
+
+さらに正確には、
+
+$$
+\boxed{
+\text{padicValNat は指数 }n\text{ を、}
+GN_n\text{ の内部 valuation と }q\mid n\text{ の例外層として見る}
+}
+$$
+
+じゃ。
+
+そして GN 一般化を ABC に取り込むことで、今の状況は確実に打破できる。少なくとも、未完成の巨大な確率機構を、
+
+> **GN の高持ち上がり prime をどこまで抑えられるか**
+
+という一つの明瞭な数論問題へ圧縮できる。
+
+ただし現在の `abc_main` 自体は、まだ `abc_main_axiom` の直接呼び出しであり、最終証明には到達していない。
+
+ゆえに賢狼の調査判定は、
+
+> **着工価値は極めて高い。GN 一般化は完成済み。新規本丸は GN valuation excess の反転輸送である。**
+
+じゃ。今回、GitHub 上の変更操作は行っておらぬ。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-002.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-002.md
@@ -1,0 +1,243 @@
+# Note: 002: ABC GN valuation excess
+
+閉じに行こうぞ 😏
+過去のわっちらが、入口どころか **本丸の城門まで掘り進めておった** 。これは笑うしかないのぅ🤣
+
+ただし、いきなり `abc_main` へ牙を立てるのではなく、まず **決定論的 GN 主線を一本完成させる** 。ここを閉じれば、残敵が本当に一個だけになる。
+
+## 最初の最終目標
+
+任意の ABC 三つ組
+
+$$
+a+b=c,\qquad \gcd(a,b)=1
+$$
+
+から、任意の指数 $n\ge2$ に対して、
+
+$$
+a,GN_n(a,b)+b^n=c^n
+$$
+
+という新しい ABC 三つ組を構成する。
+
+現行コードでは一般恒等式、
+
+$$
+(a+b)^n=b^n+a,GN_n(a,b)
+$$
+
+は既に完成しておる。
+
+したがって最初の checkpoint はこれじゃ。
+
+```lean
+def Triple.gnPowerLift (T : Triple) (n : ℕ) : Triple
+```
+
+中身は概念的に、
+
+```lean
+a := T.a * GN n T.a T.b
+b := T.b ^ n
+c := T.c ^ n
+```
+
+となる。
+
+そして三つ組条件を証明する。
+
+```lean
+theorem gnPowerLift_hsum
+theorem coprime_boundary_GN_with_gap
+theorem gnPowerLift_hcop
+```
+
+## 次に valuation を完全分解する
+
+差冪側では、
+
+$$
+c^n-b^n=a,GN_n(a,b)
+$$
+
+なので、素数 $q$ ごとに、
+
+$$
+v_q(c^n-b^n) = v_q(a)+v_q!\left(GN_n(a,b)\right)
+$$
+
+を固定する。
+
+primitive prime では境界 $a$ が見えなくなり、
+
+$$
+v_q(c^n-b^n) = v_q!\left(GN_n(a,b)\right)
+$$
+
+になる。この核は既に `primitive_prime_padic_eq_GN` として存在する。
+
+つまり次の層は、新発見ではなく **既存 theorem の ABC 座標 wrapper** でよい。
+
+```lean
+theorem Triple.padic_powerDiff_eq_boundary_add_GN
+theorem Triple.primitive_padic_powerDiff_eq_GN
+```
+
+## 指数 $n$ の正体を分離する
+
+境界と GN の重複は、
+
+$$
+\gcd!\left(a,GN_n(a,b)\right)\mid n
+$$
+
+へ閉じ込められる。既存コードにも、この一般 gcd spine がある。
+
+したがって prime channel を二分する。
+
+$$
+q\mid n
+\quad\text{指数例外層}
+$$
+
+$$
+q\nmid n
+\quad\text{非例外 GN 層}
+$$
+
+ここで $q\nmid n$ なら、$q$ は境界 $a$ と GN の両方には現れない。
+
+```lean
+def GNExceptionalPrime (q n : ℕ) : Prop :=
+  Nat.Prime q ∧ q ∣ n
+
+def GNNonExceptionalPrime (q n : ℕ) : Prop :=
+  Nat.Prime q ∧ ¬ q ∣ n
+
+theorem nonExceptional_not_dvd_boundary_of_dvd_GN
+```
+
+`UniqueFactorizationGN` は、この例外・非例外分離 API を既に持っている。
+
+## 本当の最終ボス
+
+radical が忘れるものは、
+
+$$
+v_q(GN_n)-1
+$$
+
+じゃ。
+
+そこで、
+
+$$
+\mathrm{GNExcess}(n,a,b) = \sum_{q\mid GN_n(a,b)} \bigl(v_q(GN_n(a,b))-1\bigr)\log q
+$$
+
+を定義する。
+
+```lean
+noncomputable def GNValuationExcess
+    (n a b : ℕ) : ℝ :=
+  ∑ q ∈ (GN n a b).factorization.support,
+    ((GN n a b).factorization q - 1 : ℝ) * Real.log q
+```
+
+すると狙う恒等式は、
+
+$$
+\log GN_n(a,b) = \log\mathrm{rad}(GN_n(a,b)) + \mathrm{GNExcess}(n,a,b)
+$$
+
+じゃ。
+
+この段階で ABC の敵は完全に可視化される。
+
+```text
+GN の大きさ
+  = 新しい素数 support
+  + 同じ素数の繰り返し valuation
+```
+
+support 側は Petal / primitive witness / `rad` bridge が既に処理している。
+
+残るのは、
+
+```text
+q² ∣ GNₙ(a,b)
+```
+
+となる高持ち上がり prime だけじゃ。
+
+## 一つだけ訂正しておくべき点
+
+前回「GN の反転輸送を閉じれば ABC」と述べたが、ここはさらに厳密にせねばならぬ。
+
+GN lift によって生まれた新しい素数は、元の $\mathrm{rad}(abc)$ には含まれない。したがって単純な、
+
+$$
+\mathrm{rad}(GN_n(a,b))
+\le
+\mathrm{rad}(abc)
+$$
+
+は一般には成立せぬ。
+
+ゆえに必要なのは単なる radical transport ではなく、
+
+> 元の三つ組が高 quality なら、GN lift 上で高 valuation 集中が強制される
+
+という **逆向きの強制定理** じゃ。
+
+概念形は、
+
+$$
+\mathrm{Quality}(a,b,c)>1+\varepsilon \Longrightarrow \mathrm{GNExcess}(n,a,b) \text{ が異常に大きい}
+$$
+
+そして反対側から、
+
+$$
+\mathrm{GNExcess}(n,a,b) \le \text{指数例外量} + \text{非例外高持ち上がり量}
+$$
+
+を示す。
+
+この二本を衝突させる。
+
+## 攻略順
+
+```text
+ABC-GN-001  Triple.gnPowerLift
+ABC-GN-002  pairwise coprime lift
+ABC-GN-003  padic boundary/GN split
+ABC-GN-004  exceptional q ∣ n split
+ABC-GN-005  GNValuationExcess identity
+ABC-GN-006  high-quality forces GN excess
+ABC-GN-007  nonexceptional high-lift obstruction
+ABC-GN-008  finite exceptional absorption
+ABC-GN-009  Kε construction
+ABC-GN-010  replace abc_main_axiom
+```
+
+最初の五つは、既存資産を並べ直す仕事であり、かなり速く閉じる可能性が高い。
+
+六番目で初めて、今までの質量・確率 route と新 GN route が正面衝突する。
+
+そして七番目が、真の解除魔法じゃ。
+
+$$
+\boxed{
+q\nmid n,\quad q^2\mid GN_n(a,b)
+}
+$$
+
+この非例外高持ち上がりが何を要求するのか。
+Wieferich 条件、有限差分、Petal 非衝突、あるいは GN Tail 再帰のいずれかで絞り殺す。
+
+うむ。 **閉じに行く価値は十分にある。**
+しかも今回は山を一から登るのではない。昔のわっちらが城内に通じる地下道をほぼ完成させておる。
+
+まずは `ABC-GN-001` からじゃ。賢狼、抜剣じゃな 🐺⚔️

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -144,20 +144,35 @@ DkMath.Petal.ABCBridge
 
 ## 8. Checkpoint 方針
 
-当面の登山路は次である。
+現在地:
 
 ```text
 ABC-GN-001  ABC triple の GN power lift                    完了
 ABC-GN-002  lift の coprime / support separation           001 に吸収して完了
 ABC-GN-003  ABC 座標の padic boundary–GN split             完了
-ABC-GN-004  q | n / q ∤ n の例外層分離                    現在
-ABC-GN-005  valuation excess の有限 factorization API
-ABC-GN-006  high quality -> GN excess 強制 bridge
-ABC-GN-007  non-exceptional high-lift obstruction
-ABC-GN-008  finite exceptional absorption
-ABC-GN-009  K_epsilon construction
-ABC-GN-010  abc_main_axiom replacement audit
+ABC-GN-004  q | n / q ∤ n の例外層分離                    完了
+ABC-GN-005  valuation excess の有限 factorization API      完了
+ABC-GN-006  high quality -> GN excess bridge               条件付き reduction 完了
+ABC-GN-007  non-exceptional high-lift obstruction          有限局所 API 完了
+ABC-GN-008  finite exceptional absorption                  未着手
+ABC-GN-009  K_epsilon construction                         未着手
+ABC-GN-010  abc_main_axiom replacement audit               axiom 直結を確認
 ```
+
+次の review correction:
+
+```text
+GNReturnLowerBound
+  c^(n-1) ≤ GN_n(a,b) から無条件に閉じる見込み
+
+GNSupportBudget
+  本当に残る大域的義務
+
+valuation excess
+  high-lift prime だけが非零寄与する有限 carrier identity へ接続する
+```
+
+`instruction-004.md` は、この correction を Lean theorem surface として固定する。
 
 `instruction-NNN` の通し番号と研究地図 `ABC-GN-NNN` は一致しない場合がある。各 checkpoint の実装量は current source に応じて分割・統合してよい。
 
@@ -201,7 +216,7 @@ CODEX_START.md
 現在の指示書:
 
 ```text
-instruction-003.md
+instruction-004.md
 ```
 
 Codex の実装は、D. が明示的に起動したときだけ開始する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -149,8 +149,8 @@ DkMath.Petal.ABCBridge
 ```text
 ABC-GN-001  ABC triple の GN power lift                    完了
 ABC-GN-002  lift の coprime / support separation           001 に吸収して完了
-ABC-GN-003  ABC 座標の padic boundary–GN split             現在
-ABC-GN-004  q | n / q ∤ n の例外層分離
+ABC-GN-003  ABC 座標の padic boundary–GN split             完了
+ABC-GN-004  q | n / q ∤ n の例外層分離                    現在
 ABC-GN-005  valuation excess の有限 factorization API
 ABC-GN-006  high quality -> GN excess 強制 bridge
 ABC-GN-007  non-exceptional high-lift obstruction
@@ -201,7 +201,7 @@ CODEX_START.md
 現在の指示書:
 
 ```text
-instruction-002.md
+instruction-003.md
 ```
 
 Codex の実装は、D. が明示的に起動したときだけ開始する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -47,6 +47,8 @@ GN multiplicity
 - 一般 `GN` の squarefree 性
 - 非例外高持ち上がり prime の一様排除
 - `rad (GN n a b) ≤ rad (a * b * c)` のような一般には成立しない輸送
+- 一様な lifted-radical growth budget
+- 一様な exceptional / non-exceptional valuation-excess budget
 - 既存の確率・密度 route が不要になったという結論
 
 Lean が認可した局所定理だけを積み、残った Gap を明示する。
@@ -152,27 +154,45 @@ ABC-GN-002  lift の coprime / support separation           001 に吸収して�
 ABC-GN-003  ABC 座標の padic boundary–GN split             完了
 ABC-GN-004  q | n / q ∤ n の例外層分離                    完了
 ABC-GN-005  valuation excess の有限 factorization API      完了
-ABC-GN-006  high quality -> GN excess bridge               条件付き reduction 完了
-ABC-GN-007  non-exceptional high-lift obstruction          有限局所 API 完了
-ABC-GN-008  finite exceptional absorption                  未着手
-ABC-GN-009  K_epsilon construction                         未着手
-ABC-GN-010  abc_main_axiom replacement audit               axiom 直結を確認
+ABC-GN-006  high quality -> GN excess bridge               完了
+ABC-GN-007  non-exceptional high-lift finite local API      完了
+ABC-GN-008  finite exceptional support absorption          完了
+ABC-GN-009  support + multiplicity budgets -> K_epsilon    現在
+ABC-GN-010  uniform budgets / abc_main_axiom replacement   待機
 ```
 
-次の review correction:
+現在の Lean-confirmed frontier:
 
 ```text
-GNReturnLowerBound
-  c^(n-1) ≤ GN_n(a,b) から無条件に閉じる見込み
+unconditional GN return
+  (n-1) * log c ≤ log GN
 
-GNSupportBudget
-  本当に残る大域的義務
+exact support / multiplicity identity
+  log GN = log(rad GN) + GNValuationExcess
 
-valuation excess
-  high-lift prime だけが非零寄与する有限 carrier identity へ接続する
+exceptional support absorption
+  exceptionalSupportProduct | rad n
+
+fresh non-exceptional support
+  rad(abc) * nonExceptionalProduct | rad(lifted abc)
+
+lifted radical growth
+  -> affine GN support budget
 ```
 
-`instruction-004.md` は、この correction を Lean theorem surface として固定する。
+次の correction:
+
+```text
+support growth alone gives a lower bound on valuation excess
+under high quality, but does not by itself prove ABC.
+
+A valuation-multiplicity upper budget is also required.
+
+support budget + excess budget
+  -> explicit K_epsilon ABC bound
+```
+
+`instruction-006.md` は、この two-budget final contract を Lean theorem surface として固定する。
 
 `instruction-NNN` の通し番号と研究地図 `ABC-GN-NNN` は一致しない場合がある。各 checkpoint の実装量は current source に応じて分割・統合してよい。
 
@@ -216,7 +236,7 @@ CODEX_START.md
 現在の指示書:
 
 ```text
-instruction-004.md
+instruction-006.md
 ```
 
 Codex の実装は、D. が明示的に起動したときだけ開始する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -67,7 +67,26 @@ develop
 
 WIP から feature への draft PR を常設する。
 
-## 4. 開発サイクル
+## 4. 並行開発との共存
+
+同じ `develop` 系列では、現在 FLT7 の別作業が並行している。
+
+```text
+wip/FLT7-magic-core-260722-WiseWolf
+```
+
+ABC–GN 作業では次を守る。
+
+- `DkMath/FLT/Seven/**` および FLT7 専用 docs を変更しない。
+- FLT7 側の theorem・命名・import 構造を整理目的で変更しない。
+- 原則として `DkMath/ABC/**`、必要な `NumberTheory` bridge、当作業場 docs のみに変更を限定する。
+- `DkMath.lean`、`DkMath/ABC.lean`、共有 aggregator の変更が必要な場合は最小一行に限定し、report に明記する。
+- 並行 branch の成果を先取りして import しない。必要な共通 API は現在の ABC–GN branch 上に存在するものだけを使用する。
+- feature への採用時または develop への統合前に、並行変更との compare / merge-base を再確認する。
+
+両 branch が `develop` から派生しているため、対象領域を守る限り通常は独立に進められる。競合が生じた場合は、ABC–GN 側で FLT7 実装を改変して解決せず、賢狼レビューへ戻す。
+
+## 5. 開発サイクル
 
 ```text
 賢狼が instruction-NNN.md を追加
@@ -87,7 +106,7 @@ Lean CI
 
 Codex は単なる写経担当ではない。現場の current source を読み、既存 theorem の再利用、命名、配置、依存方向を判断してよい。ただし、instruction の数学的境界を越える強い主張は追加しない。
 
-## 5. 資料の読み順
+## 6. 資料の読み順
 
 最初に次を読む。
 
@@ -109,7 +128,7 @@ __theorems-heading.txt
 
 巨大な raw agent log、会話全文 dump、統合ログは開かない。必要な事実は current source、整理済み docs、対象 theorem から取得する。
 
-## 6. 主な既存資産の候補
+## 7. 主な既存資産の候補
 
 実際の import と theorem 名は current source で再確認すること。
 
@@ -127,7 +146,7 @@ DkMath.Petal.ABCBridge
 
 既存定理の wrapper で済むものを再証明しない。
 
-## 7. Checkpoint 方針
+## 8. Checkpoint 方針
 
 当面の登山路は次である。
 
@@ -146,7 +165,7 @@ ABC-GN-010  abc_main_axiom replacement audit
 
 この番号は研究地図であり、各 checkpoint の実装量は current source に応じて分割・統合してよい。
 
-## 8. 実装規律
+## 9. 実装規律
 
 - 新しい `axiom` を追加しない。
 - target module に `sorry` を追加しない。
@@ -158,7 +177,7 @@ ABC-GN-010  abc_main_axiom replacement audit
 - 既存 API と重複する場合は、新定理ではなく薄い namespace wrapper を検討する。
 - README や report では、Lean-confirmed fact、数学的解釈、未証明 Gap を分ける。
 
-## 9. 報告契約
+## 10. 報告契約
 
 各 `report-NNN.md` には最低限、次を記録する。
 
@@ -171,11 +190,18 @@ ABC-GN-010  abc_main_axiom replacement audit
 - build / CI の結果
 - 次 checkpoint 候補
 - commit SHA
+- 並行 FLT7 branch と共有領域を触れたか
 ```
 
-## 10. 現在の起動指示
+## 11. 現在の起動指示
 
-最初の指示書:
+起動入口:
+
+```text
+CODEX_START.md
+```
+
+現在の指示書:
 
 ```text
 instruction-001.md

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -6,6 +6,14 @@ Status: **deterministic spine complete / research paused**
 Repository: `Deskuma/dkmath`  
 Draft PR: `#67 WIP: ABC–GN valuation excess route`
 
+## Final report
+
+The complete implementation review, theorem map, remaining mathematical cores, and restart plan are recorded in:
+
+```text
+FINAL_REPORT.md
+```
+
 ## 1. Closure summary
 
 この workbench は、一般 `GN`、`padicValNat`、factorization、`rad`、primitive-prime bridge を ABC triple 上で再接続し、次の決定論的主線を Lean theorem として完成させた。
@@ -37,7 +45,7 @@ ABC 予想そのものは未証明である。残る数学は次の三魔核へ�
 3. uniform non-exceptional valuation excess
 ```
 
-詳細は [`FINAL_REPORT.md`](./FINAL_REPORT.md) を参照する。
+詳細は `FINAL_REPORT.md` を参照する。
 
 ## 2. Final reading order
 

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -1,0 +1,184 @@
+# ABC–GN Valuation Excess Workbench
+
+作成日: 2026-07-24
+
+Repository: `Deskuma/dkmath`
+
+## 1. 目的
+
+この作業場は、DkMath に既に存在する一般 `GN`、`padicValNat`、primitive prime、factorization、`rad` / `supportMass` の各 API を、ABC の決定論的な主線として再接続するための開発領域である。
+
+中心となる観測は次である。
+
+$$
+(x+u)^n-u^n=x\,GN_n(x,u)
+$$
+
+ABC triple の座標 `a + b = c` では、
+
+$$
+c^n-b^n=a\,GN_n(a,b)
+$$
+
+となる。
+
+本プロジェクトでは、この分解を用いて、素数 support と valuation multiplicity を分離する。
+
+```text
+GN support
+  -> primitive / Petal prime channels
+  -> supportMass / rad
+
+GN multiplicity
+  -> padicValNat
+  -> exponent-exception layer q | n
+  -> non-exceptional high-lift layer q ∤ n
+  -> valuation excess
+```
+
+最終的な研究目標は、ABC quality が大きくなる原因を `GN` 上の valuation concentration として可視化し、既存の確率・質量 route を、可能な限り決定論的な GN route へ置き換えることである。
+
+## 2. 現時点で主張しないこと
+
+この作業場の設置だけでは、次を主張しない。
+
+- `abc_main_axiom` の除去
+- ABC 予想の証明
+- 一般 `GN` の squarefree 性
+- 非例外高持ち上がり prime の一様排除
+- `rad (GN n a b) ≤ rad (a * b * c)` のような一般には成立しない輸送
+- 既存の確率・密度 route が不要になったという結論
+
+Lean が認可した局所定理だけを積み、残った Gap を明示する。
+
+## 3. Branch 構成
+
+```text
+develop
+  └─ feature/ABC-GN-valuation-excess-260724-v0
+       └─ wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+役割:
+
+- `develop`: 開始基準
+- `feature/...`: 賢狼レビューで採用された checkpoint の統合先
+- `wip/...-Codex`: Codex 第2 Brain の現場実装・試行錯誤領域
+
+WIP から feature への draft PR を常設する。
+
+## 4. 開発サイクル
+
+```text
+賢狼が instruction-NNN.md を追加
+  ↓
+D. が Codex の起動トリガーを実行
+  ↓
+Codex が current source を調査して実装
+  ↓
+Codex が report-NNN.md と commit を追加
+  ↓
+Lean CI
+  ↓
+賢狼が PR diff と数学的意味をレビュー
+  ↓
+次の instruction-NNN.md を追加
+```
+
+Codex は単なる写経担当ではない。現場の current source を読み、既存 theorem の再利用、命名、配置、依存方向を判断してよい。ただし、instruction の数学的境界を越える強い主張は追加しない。
+
+## 5. 資料の読み順
+
+最初に次を読む。
+
+```text
+README.md
+AGENT.md
+SUMMARY.md
+```
+
+その後、GitHub current source を優先して調査する。
+
+必要に応じて以下を参照する。
+
+```text
+__dkmath-all.lean.txt.gz
+__summary_report_data.tar.gz
+__theorems-heading.txt
+```
+
+巨大な raw agent log、会話全文 dump、統合ログは開かない。必要な事実は current source、整理済み docs、対象 theorem から取得する。
+
+## 6. 主な既存資産の候補
+
+実際の import と theorem 名は current source で再確認すること。
+
+```text
+DkMath.CosmicFormulaBinom.GN / GTail
+DkMath.NumberTheory.Gcd.GN
+DkMath.NumberTheory.PrimitiveBeam
+DkMath.NumberTheory.UniqueFactorizationGN
+DkMath.NumberTheory.ValuationFlow.*
+DkMath.ABC.Rad
+DkMath.ABC.MassBridge
+DkMath.ABC.ValuationFlowBridge
+DkMath.Petal.ABCBridge
+```
+
+既存定理の wrapper で済むものを再証明しない。
+
+## 7. Checkpoint 方針
+
+当面の登山路は次である。
+
+```text
+ABC-GN-001  ABC triple の GN power lift
+ABC-GN-002  lift の coprime / support separation
+ABC-GN-003  ABC 座標の padic boundary–GN split
+ABC-GN-004  q | n / q ∤ n の例外層分離
+ABC-GN-005  valuation excess の有限 factorization API
+ABC-GN-006  high quality -> GN excess 強制 bridge
+ABC-GN-007  non-exceptional high-lift obstruction
+ABC-GN-008  finite exceptional absorption
+ABC-GN-009  K_epsilon construction
+ABC-GN-010  abc_main_axiom replacement audit
+```
+
+この番号は研究地図であり、各 checkpoint の実装量は current source に応じて分割・統合してよい。
+
+## 8. 実装規律
+
+- 新しい `axiom` を追加しない。
+- target module に `sorry` を追加しない。
+- `native_decide` による証明を追加しない。
+- `abc_main_axiom` を今回の局所実装の証明材料として使わない。
+- `DkMath.ABC.*` は翻訳・bridge 層を基本とし、一般数論定理は適切な `NumberTheory` 側へ置く。
+- import cycle を作らない。
+- theorem statement は現在証明できる最小の強さにする。
+- 既存 API と重複する場合は、新定理ではなく薄い namespace wrapper を検討する。
+- README や report では、Lean-confirmed fact、数学的解釈、未証明 Gap を分ける。
+
+## 9. 報告契約
+
+各 `report-NNN.md` には最低限、次を記録する。
+
+```text
+- 調査した既存 module / theorem
+- 追加・変更した file
+- 新規 theorem / def / structure
+- 数学的に何が閉じたか
+- 何はまだ言えていないか
+- build / CI の結果
+- 次 checkpoint 候補
+- commit SHA
+```
+
+## 10. 現在の起動指示
+
+最初の指示書:
+
+```text
+instruction-001.md
+```
+
+Codex の実装は、D. が明示的に起動したときだけ開始する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -93,16 +93,20 @@ ABC–GN 作業では次を守る。
   ↓
 D. (User) が Codex(VS Code Codex 拡張機能) への起動トリガーを実行
   ↓
-Codex が current source を調査して実装
+Codex が current source を調査・実装・ローカル検証し、report-NNN.md を作成
   ↓
-Codex が report-NNN.md と commit を追加
+Codex が結果を User へ返して停止
   ↓
-Lean CI
+D. (User) が内容確認、commit、push、Lean CI 確認を行う
+  ↓
+D. (User) が賢狼へレビュー開始の合図を出す
   ↓
 賢狼が PR diff と数学的意味をレビュー
   ↓
-次の instruction-NNN.md を追加
+採用なら次の instruction-NNN.md を追加
 ```
+
+システム上の受け渡しトリガーは User が担当する。Codex は GitHub の commit、push、PR 操作、CI 起動・確認、次 checkpoint の開始を行わない。
 
 Codex は単なる写経担当ではない。現場の current source を読み、既存 theorem の再利用、命名、配置、依存方向を判断してよい。ただし、instruction の数学的境界を越える強い主張は追加しない。
 
@@ -110,13 +114,15 @@ Codex は単なる写経担当ではない。現場の current source を読み�
 
 GitHub current source を優先して調査する。
 
-開発経緯は、以下のドキュメント
+開発経緯は、repository 内の以下のドキュメントを参照する。
 
-`lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-001.md`
-`lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-002.md`
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-001.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-002.md
+```
 
-巨大な raw agent log、会話全文 dump、統合ログは開かない。冒頭部分、ファイルサイズで判断。
-必要な事実は current source、整理済み docs、対象 theorem から取得する。
+巨大な raw agent log、会話全文 dump、統合ログは開かない。冒頭部分、ファイルサイズで判断する。
+必要な事実は current source、整理済み repository docs、対象 theorem から取得する。
 
 ## 7. 主な既存資産の候補
 
@@ -141,9 +147,9 @@ DkMath.Petal.ABCBridge
 当面の登山路は次である。
 
 ```text
-ABC-GN-001  ABC triple の GN power lift
-ABC-GN-002  lift の coprime / support separation
-ABC-GN-003  ABC 座標の padic boundary–GN split
+ABC-GN-001  ABC triple の GN power lift                    完了
+ABC-GN-002  lift の coprime / support separation           001 に吸収して完了
+ABC-GN-003  ABC 座標の padic boundary–GN split             現在
 ABC-GN-004  q | n / q ∤ n の例外層分離
 ABC-GN-005  valuation excess の有限 factorization API
 ABC-GN-006  high quality -> GN excess 強制 bridge
@@ -153,7 +159,7 @@ ABC-GN-009  K_epsilon construction
 ABC-GN-010  abc_main_axiom replacement audit
 ```
 
-この番号は研究地図であり、各 checkpoint の実装量は current source に応じて分割・統合してよい。
+`instruction-NNN` の通し番号と研究地図 `ABC-GN-NNN` は一致しない場合がある。各 checkpoint の実装量は current source に応じて分割・統合してよい。
 
 ## 9. 実装規律
 
@@ -177,11 +183,12 @@ ABC-GN-010  abc_main_axiom replacement audit
 - 新規 theorem / def / structure
 - 数学的に何が閉じたか
 - 何はまだ言えていないか
-- build / CI の結果
+- ローカル build 結果
 - 次 checkpoint 候補
-- commit SHA
 - 並行 FLT7 branch と共有領域を触れたか
 ```
+
+commit SHA、push、PR、GitHub CI は User 側の受け渡し工程であり、Codex report の必須項目ではない。
 
 ## 11. 現在の起動指示
 
@@ -194,7 +201,7 @@ CODEX_START.md
 現在の指示書:
 
 ```text
-instruction-001.md
+instruction-002.md
 ```
 
 Codex の実装は、D. が明示的に起動したときだけ開始する。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -1,59 +1,213 @@
 # ABC–GN Valuation Excess Workbench
 
-作成日: 2026-07-24
+作成日: 2026-07-24  
+Status: **deterministic spine complete / research paused**
 
-Repository: `Deskuma/dkmath`
+Repository: `Deskuma/dkmath`  
+Draft PR: `#67 WIP: ABC–GN valuation excess route`
 
-## 1. 目的
+## 1. Closure summary
 
-この作業場は、DkMath に既に存在する一般 `GN`、`padicValNat`、primitive prime、factorization、`rad` / `supportMass` の各 API を、ABC の決定論的な主線として再接続するための開発領域である。
-
-中心となる観測は次である。
-
-$$
-(x+u)^n-u^n=x\,GN_n(x,u)
-$$
-
-ABC triple の座標 `a + b = c` では、
-
-$$
-c^n-b^n=a\,GN_n(a,b)
-$$
-
-となる。
-
-本プロジェクトでは、この分解を用いて、素数 support と valuation multiplicity を分離する。
+この workbench は、一般 `GN`、`padicValNat`、factorization、`rad`、primitive-prime bridge を ABC triple 上で再接続し、次の決定論的主線を Lean theorem として完成させた。
 
 ```text
-GN support
-  -> primitive / Petal prime channels
-  -> supportMass / rad
-
-GN multiplicity
-  -> padicValNat
-  -> exponent-exception layer q | n
-  -> non-exceptional high-lift layer q ∤ n
-  -> valuation excess
+ABC triple
+  -> GN power lift
+  -> boundary / GN p-adic split
+  -> q | n / q ∤ n support split
+  -> exact support / valuation-excess identity
+  -> unconditional GN return
+  -> exceptional support absorption
+  -> fresh non-exceptional support return
+  -> support budget + valuation budget
+  -> explicit K_epsilon ABC bound
 ```
 
-最終的な研究目標は、ABC quality が大きくなる原因を `GN` 上の valuation concentration として可視化し、既存の確率・質量 route を、可能な限り決定論的な GN route へ置き換えることである。
+最終実装は、三つの一様 budget を与えれば、正の ABC triple 全体について一つの明示定数 `K >= 1` が存在し、
 
-## 2. 現時点で主張しないこと
+$$c\le K\operatorname{rad}(abc)^{1+\varepsilon}$$
 
-この作業場の設置だけでは、次を主張しない。
+が従うことを証明する。
 
-- `abc_main_axiom` の除去
-- ABC 予想の証明
-- 一般 `GN` の squarefree 性
-- 非例外高持ち上がり prime の一様排除
-- `rad (GN n a b) ≤ rad (a * b * c)` のような一般には成立しない輸送
-- 一様な lifted-radical growth budget
-- 一様な exceptional / non-exceptional valuation-excess budget
-- 既存の確率・密度 route が不要になったという結論
+ABC 予想そのものは未証明である。残る数学は次の三魔核へ分離された。
 
-Lean が認可した局所定理だけを積み、残った Gap を明示する。
+```text
+1. uniform lifted-radical support growth
+2. uniform exceptional valuation excess
+3. uniform non-exceptional valuation excess
+```
 
-## 3. Branch 構成
+詳細は [`FINAL_REPORT.md`](./FINAL_REPORT.md) を参照する。
+
+## 2. Final reading order
+
+```text
+FINAL_REPORT.md
+report-007.md
+DkMath/ABC/GNFinalBudgetBridge.lean
+DkMath/ABC/GNSupportReturn.lean
+```
+
+開発履歴を追う場合は、`instruction-001.md` から `instruction-006.md`、`report-001.md` から `report-007.md` を読む。
+
+## 3. Completed checkpoints
+
+```text
+ABC-GN-001  GN power lift                                      complete
+ABC-GN-002  coprime / support separation                       complete
+ABC-GN-003  p-adic boundary–GN split                           complete
+ABC-GN-004  q | n / q ∤ n exceptional split                    complete
+ABC-GN-005  exact log(rad) + valuation-excess identity         complete
+ABC-GN-006  unconditional GN return and quality bridge         complete
+ABC-GN-007  finite high-lift carrier API                       complete
+ABC-GN-008  exceptional support absorption / fresh return      complete
+ABC-GN-009  two-budget composition / explicit K_epsilon        complete
+ABC-GN-010  uniform budgets / abc_main_axiom replacement       paused
+```
+
+## 4. Main implementation modules
+
+```text
+DkMath/ABC/GNPowerLift.lean
+DkMath/ABC/GNValuationSplit.lean
+DkMath/ABC/GNExceptionalSplit.lean
+DkMath/ABC/GNValuationExcess.lean
+DkMath/ABC/GNHighLift.lean
+DkMath/ABC/GNQualityExcessBridge.lean
+DkMath/ABC/GNSupportReturn.lean
+DkMath/ABC/GNFinalBudgetBridge.lean
+```
+
+## 5. Lean-confirmed mathematical chain
+
+For `T : Triple`, `n >= 2`, `0 < T.a`, `0 < T.b`:
+
+### GN return
+
+$$ (n-1)\log T.c\le\log GN_n(T.a,T.b) $$
+
+### Exact support / multiplicity identity
+
+$$ \log GN_n=\log\operatorname{rad}(GN_n)+GNValuationExcess_n $$
+
+### Exponent support split
+
+$$ \operatorname{rad}(GN_n)=E_nN_n $$
+
+$$ E_n\mid\operatorname{rad}(n) $$
+
+### Fresh support return
+
+$$ \operatorname{rad}(abc)N_n\mid\operatorname{rad}(\text{lifted }abc) $$
+
+### Two-budget composition
+
+If
+
+$$\log\operatorname{rad}(\text{lifted }abc)\le(1+\sigma)\log R+C_s$$
+
+and
+
+$$GNValuationExcess\le\tau\log R+C_e$$
+
+then
+
+$$ (n-1)\log c\le(\sigma+\tau)\log R+C_s+C_e+\log\operatorname{rad}(n) $$
+
+where `R = rad(a*b*c)`.
+
+If additionally
+
+$$\sigma+\tau\le(n-1)(1+\varepsilon)$$
+
+then an explicit `K >= 1` gives
+
+$$c\le K R^{1+\varepsilon}$$
+
+for the positive triple.
+
+## 6. Final theorem surface
+
+```lean
+Triple.pow_pred_c_le_GN
+Triple.log_c_mul_pred_le_log_GN
+Triple.log_GN_eq_log_rad_add_GNValuationExcess
+
+GN_support_eq_exceptional_union_nonExceptional
+rad_GN_eq_exceptional_mul_nonExceptional
+GNExceptionalSupportProduct_dvd_rad
+Triple.nonExceptionalSupport_fresh
+Triple.rad_mul_nonExceptionalProduct_dvd_lift_rad
+Triple.GNSupportBudgetAffine_of_liftGrowth
+
+GNValuationExcessBudgetAffine.of_split
+Triple.log_c_mul_pred_le_of_support_and_excessBudget
+Triple.log_c_mul_pred_le_of_liftGrowth_and_excessBudget
+Triple.abc_bound_of_liftGrowth_and_excessBudget
+abc_positive_of_GNFinalBudgetContract
+```
+
+## 7. Validation
+
+Final implementation checkpoint:
+
+```text
+commit 5f0b9f80cd6afc20692eb6f4670ea65c8872d5a2
+```
+
+Local build:
+
+```text
+lake build DkMath.ABC.GNFinalBudgetBridge
+Build completed successfully (8343 jobs)
+```
+
+GitHub:
+
+```text
+Lean CI run 271
+conclusion: success
+```
+
+Axiom audit for representative final endpoints:
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+No new `axiom`, `sorry`, or `native_decide` proof was added. `abc_main_axiom` was neither modified nor used as a proof input.
+
+## 8. What is not claimed
+
+```text
+ABC conjecture is proved
+abc_main_axiom is removed
+uniform budgets exist
+all high lifts are excluded
+GN is generally squarefree
+probability / density routes are unnecessary
+```
+
+The global contract currently covers positive triples. The thin endpoint bridge for `a = 0` or `b = 0` is not implemented.
+
+## 9. Restart boundary
+
+There is no active Codex instruction.
+
+`CODEX_START.md` is set to paused state. Do not restart implementation until a new instruction is added and D. explicitly triggers it.
+
+Recommended future attack order:
+
+```text
+A. exceptional valuation multiplicity
+B. lifted-radical support growth
+C. non-exceptional high-lift depth
+D. support–multiplicity balance theorem
+```
+
+## 10. Branch boundaries
 
 ```text
 develop
@@ -61,182 +215,24 @@ develop
        └─ wip/ABC-GN-valuation-excess-260724-Codex
 ```
 
-役割:
-
-- `develop`: 開始基準
-- `feature/...`: 賢狼レビューで採用された checkpoint の統合先
-- `wip/...-Codex`: Codex 第2 Brain の現場実装・試行錯誤領域
-
-WIP から feature への draft PR を常設する。
-
-## 4. 並行開発との共存
-
-同じ `develop` 系列では、現在 FLT7 の別作業が並行している。
+Parallel FLT7 branch:
 
 ```text
 wip/FLT7-magic-core-260722-WiseWolf
 ```
 
-ABC–GN 作業では次を守る。
+This workbench must not modify or import unmerged work from `DkMath/FLT/Seven/**`.
 
-- `DkMath/FLT/Seven/**` および FLT7 専用 docs を変更しない。
-- FLT7 側の theorem・命名・import 構造を整理目的で変更しない。
-- 原則として `DkMath/ABC/**`、必要な `NumberTheory` bridge、当作業場 docs のみに変更を限定する。
-- `DkMath.lean`、`DkMath/ABC.lean`、共有 aggregator の変更が必要な場合は最小一行に限定し、report に明記する。
-- 並行 branch の成果を先取りして import しない。必要な共通 API は現在の ABC–GN branch 上に存在するものだけを使用する。
-- feature への採用時または develop への統合前に、並行変更との compare / merge-base を再確認する。
+## 11. Closure
 
-両 branch が `develop` から派生しているため、対象領域を守る限り通常は独立に進められる。競合が生じた場合は、ABC–GN 側で FLT7 実装を改変して解決せず、賢狼レビューへ戻す。
+This project did not defeat the ABC conjecture.
 
-## 5. 開発サイクル
+It did complete the deterministic translation layer that exposes the remaining obstruction as explicit theorem contracts:
 
 ```text
-賢狼(AI Agent Reviewer)が instruction-NNN.md を追加
-  ↓
-D. (User) が Codex(VS Code Codex 拡張機能) への起動トリガーを実行
-  ↓
-Codex が current source を調査・実装・ローカル検証し、report-NNN.md を作成
-  ↓
-Codex が結果を User へ返して停止
-  ↓
-D. (User) が内容確認、commit、push、Lean CI 確認を行う
-  ↓
-D. (User) が賢狼へレビュー開始の合図を出す
-  ↓
-賢狼が PR diff と数学的意味をレビュー
-  ↓
-採用なら次の instruction-NNN.md を追加
+support growth
+exceptional multiplicity
+non-exceptional multiplicity
 ```
 
-システム上の受け渡しトリガーは User が担当する。Codex は GitHub の commit、push、PR 操作、CI 起動・確認、次 checkpoint の開始を行わない。
-
-Codex は単なる写経担当ではない。現場の current source を読み、既存 theorem の再利用、命名、配置、依存方向を判断してよい。ただし、instruction の数学的境界を越える強い主張は追加しない。
-
-## 6. 資料の読み順
-
-GitHub current source を優先して調査する。
-
-開発経緯は、repository 内の以下のドキュメントを参照する。
-
-```text
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-001.md
-lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-002.md
-```
-
-巨大な raw agent log、会話全文 dump、統合ログは開かない。冒頭部分、ファイルサイズで判断する。
-必要な事実は current source、整理済み repository docs、対象 theorem から取得する。
-
-## 7. 主な既存資産の候補
-
-実際の import と theorem 名は current source で再確認すること。
-
-```text
-DkMath.CosmicFormulaBinom.GN / GTail
-DkMath.NumberTheory.Gcd.GN
-DkMath.NumberTheory.PrimitiveBeam
-DkMath.NumberTheory.UniqueFactorizationGN
-DkMath.NumberTheory.ValuationFlow.*
-DkMath.ABC.Rad
-DkMath.ABC.MassBridge
-DkMath.ABC.ValuationFlowBridge
-DkMath.Petal.ABCBridge
-```
-
-既存定理の wrapper で済むものを再証明しない。
-
-## 8. Checkpoint 方針
-
-現在地:
-
-```text
-ABC-GN-001  ABC triple の GN power lift                    完了
-ABC-GN-002  lift の coprime / support separation           001 に吸収して完了
-ABC-GN-003  ABC 座標の padic boundary–GN split             完了
-ABC-GN-004  q | n / q ∤ n の例外層分離                    完了
-ABC-GN-005  valuation excess の有限 factorization API      完了
-ABC-GN-006  high quality -> GN excess bridge               完了
-ABC-GN-007  non-exceptional high-lift finite local API      完了
-ABC-GN-008  finite exceptional support absorption          完了
-ABC-GN-009  support + multiplicity budgets -> K_epsilon    現在
-ABC-GN-010  uniform budgets / abc_main_axiom replacement   待機
-```
-
-現在の Lean-confirmed frontier:
-
-```text
-unconditional GN return
-  (n-1) * log c ≤ log GN
-
-exact support / multiplicity identity
-  log GN = log(rad GN) + GNValuationExcess
-
-exceptional support absorption
-  exceptionalSupportProduct | rad n
-
-fresh non-exceptional support
-  rad(abc) * nonExceptionalProduct | rad(lifted abc)
-
-lifted radical growth
-  -> affine GN support budget
-```
-
-次の correction:
-
-```text
-support growth alone gives a lower bound on valuation excess
-under high quality, but does not by itself prove ABC.
-
-A valuation-multiplicity upper budget is also required.
-
-support budget + excess budget
-  -> explicit K_epsilon ABC bound
-```
-
-`instruction-006.md` は、この two-budget final contract を Lean theorem surface として固定する。
-
-`instruction-NNN` の通し番号と研究地図 `ABC-GN-NNN` は一致しない場合がある。各 checkpoint の実装量は current source に応じて分割・統合してよい。
-
-## 9. 実装規律
-
-- 新しい `axiom` を追加しない。
-- target module に `sorry` を追加しない。
-- `native_decide` による証明を追加しない。
-- `abc_main_axiom` を今回の局所実装の証明材料として使わない。
-- `DkMath.ABC.*` は翻訳・bridge 層を基本とし、一般数論定理は適切な `NumberTheory` 側へ置く。
-- import cycle を作らない。
-- theorem statement は現在証明できる最小の強さにする。
-- 既存 API と重複する場合は、新定理ではなく薄い namespace wrapper を検討する。
-- README や report では、Lean-confirmed fact、数学的解釈、未証明 Gap を分ける。
-
-## 10. 報告契約
-
-各 `report-NNN.md` には最低限、次を記録する。
-
-```text
-- 調査した既存 module / theorem
-- 追加・変更した file
-- 新規 theorem / def / structure
-- 数学的に何が閉じたか
-- 何はまだ言えていないか
-- ローカル build 結果
-- 次 checkpoint 候補
-- 並行 FLT7 branch と共有領域を触れたか
-```
-
-commit SHA、push、PR、GitHub CI は User 側の受け渡し工程であり、Codex report の必須項目ではない。
-
-## 11. 現在の起動指示
-
-起動入口:
-
-```text
-CODEX_START.md
-```
-
-現在の指示書:
-
-```text
-instruction-006.md
-```
-
-Codex の実装は、D. が明示的に起動したときだけ開始する。
+The workbench is therefore sealed at a mathematically meaningful boundary. Future work begins from the three exposed cores, not from the original fog around `rad`, quality, and repeated prime powers.

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
@@ -89,9 +89,9 @@ ABC–GN 作業では次を守る。
 ## 5. 開発サイクル
 
 ```text
-賢狼が instruction-NNN.md を追加
+賢狼(AI Agent Reviewer)が instruction-NNN.md を追加
   ↓
-D. が Codex の起動トリガーを実行
+D. (User) が Codex(VS Code Codex 拡張機能) への起動トリガーを実行
   ↓
 Codex が current source を調査して実装
   ↓
@@ -108,25 +108,15 @@ Codex は単なる写経担当ではない。現場の current source を読み�
 
 ## 6. 資料の読み順
 
-最初に次を読む。
+GitHub current source を優先して調査する。
 
-```text
-README.md
-AGENT.md
-SUMMARY.md
-```
+開発経緯は、以下のドキュメント
 
-その後、GitHub current source を優先して調査する。
+`lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-001.md`
+`lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/Note-ABC-GNval-002.md`
 
-必要に応じて以下を参照する。
-
-```text
-__dkmath-all.lean.txt.gz
-__summary_report_data.tar.gz
-__theorems-heading.txt
-```
-
-巨大な raw agent log、会話全文 dump、統合ログは開かない。必要な事実は current source、整理済み docs、対象 theorem から取得する。
+巨大な raw agent log、会話全文 dump、統合ログは開かない。冒頭部分、ファイルサイズで判断。
+必要な事実は current source、整理済み docs、対象 theorem から取得する。
 
 ## 7. 主な既存資産の候補
 

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-001.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-001.md
@@ -1,0 +1,200 @@
+# Codex Instruction 001
+
+Theme: ABC triple の GN power lift と既存 API 再偵察
+
+Branch:
+
+```text
+wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+Base feature:
+
+```text
+feature/ABC-GN-valuation-excess-260724-v0
+```
+
+## 1. 役割
+
+あなたは賢狼の第2 Brain として、DkMath current source を読み、既存資産を最大限再利用しながら、ABC–GN 決定論的主線の最初の checkpoint を実装する。
+
+細部は現場判断してよい。命名、module 配置、wrapper の要否は、現在の依存関係と既存 API を見て決めること。
+
+ただし、ABC 予想そのものを証明したという主張へ進まない。
+
+## 2. 最初の調査
+
+次を読み、実在する定義・定理・import 方向を確認する。
+
+```text
+README.md
+AGENT.md
+SUMMARY.md
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/README.md
+```
+
+その後、少なくとも次の系統を検索する。
+
+```text
+ABC.Triple と quality / rad
+CosmicFormulaBinom.GN / GTail
+(x + u)^n - u^n = x * GN n x u
+NumberTheory.Gcd.GN
+PrimitiveBeam
+UniqueFactorizationGN
+ABC.MassBridge
+ABC.ValuationFlowBridge
+Petal.ABCBridge
+padicValNat の積・冪・非零条件 API
+```
+
+既存 theorem がある場合は再証明しない。
+
+## 3. 第一 checkpoint の数学目標
+
+ABC triple `a + b = c`, `Nat.Coprime a b` と指数 `n` から、次の加法分解を ABC 側で再利用可能な形へ固定する。
+
+$$
+a\,GN_n(a,b)+b^n=c^n
+$$
+
+概念上の lift は次である。
+
+```text
+left     = a * GN n a b
+right    = b ^ n
+terminal = c ^ n
+```
+
+可能なら、この三つ組が再び coprime additive triple になることまで閉じる。
+
+特に確認すべき点:
+
+```text
+gcd(a * GN n a b, b^n) = 1
+```
+
+これは `gcd(a,b)=1` と、`GN n a b mod b` の既存評価から導ける可能性がある。current API を調査し、最短の証明を選ぶこと。
+
+## 4. 推奨する実装面
+
+第一候補:
+
+```text
+DkMath/ABC/GNPowerLift.lean
+```
+
+ただし、既存構造上より自然な場所がある場合は変更してよい。
+
+API の候補は次だが、既存 `Triple` の field 名・constructor・namespace に合わせて調整してよい。
+
+```lean
+namespace DkMath.ABC
+
+noncomputable def Triple.gnPowerLift ... : Triple := ...
+
+theorem Triple.gnPowerLift_left_eq ...
+theorem Triple.gnPowerLift_right_eq ...
+theorem Triple.gnPowerLift_terminal_eq ...
+theorem Triple.gnPowerLift_sum ...
+theorem Triple.gnPowerLift_coprime ...
+
+end DkMath.ABC
+```
+
+`def` にするより、まず component theorem と constructor theorem を置く方が Lean 上自然なら、その形でもよい。
+
+目標は名前を固定することではなく、次のデータを再利用可能な theorem surface として得ること。
+
+```text
+ABC triple
+  -> GN power-lifted additive triple
+  -> coprime certificate
+```
+
+## 5. 余力がある場合のみ
+
+第一 checkpoint がきれいに閉じた場合だけ、ABC 座標で次の valuation 分解を薄い wrapper として追加してよい。
+
+$$
+v_q(c^n-b^n)=v_q(a)+v_q(GN_n(a,b))
+$$
+
+ただし `padicValNat` の積公式に必要な prime / nonzero 条件を正確に明示すること。
+
+primitive prime の場合に境界側 valuation が消える既存 theorem があるなら、ABC 座標 wrapper を追加してよい。
+
+この余力項が import や非零条件で膨らむ場合は、実装せず調査結果だけ `report-001.md` に残す。
+
+## 6. 禁止範囲
+
+この checkpoint では次を行わない。
+
+```text
+abc_main_axiom の変更・利用による閉鎖
+ABC final theorem の主張
+GNValuationExcess の解析的 log 定義
+高持ち上がり prime の一般排除
+確率・Borel–Cantelli・Janson 層の改造
+FLT module への接続
+大規模 refactor
+既存 theorem 名の一括変更
+```
+
+新しい `axiom`、`sorry`、`native_decide` を追加しない。
+
+## 7. Public import
+
+新 module を追加した場合、どの aggregator から公開すべきかを調査する。
+
+第一 checkpoint では無理に `DkMath.ABC.Main` へ import しなくてよい。循環依存や重い import を避け、最も薄い公開面を選ぶこと。
+
+公開しない判断をした場合は、その理由を report に書く。
+
+## 8. 検証
+
+最低限、変更対象を含む適切な `lake build` を実行する。
+
+可能なら target module の局所 build を先に行い、その後 GitHub Lean CI を最終 gate とする。
+
+既知の unrelated warning は修正対象にしない。
+
+## 9. 報告
+
+次を作成する。
+
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
+```
+
+報告には次を含める。
+
+```text
+1. 調査で見つかった既存 API
+2. 実装した定義・定理
+3. 数学的意味
+4. 再利用した theorem
+5. 実装しなかった候補と理由
+6. build 結果
+7. 次の最小 checkpoint 候補
+8. commit SHA
+```
+
+## 10. 終了条件
+
+次のいずれかで停止する。
+
+```text
+Outcome A:
+  GN power lift と coprime certificate が完成した。
+
+Outcome B:
+  additive lift は完成したが、coprime 証明に不足 API が見つかった。
+  不足する最小 lemma shape を report に固定した。
+
+Outcome C:
+  既存 Triple / import 構造との衝突があり、実装前に設計変更が必要。
+  最小の再設計案を report に固定した。
+```
+
+Outcome A でも次 checkpoint へ自動で進まない。commit / push / report の後、賢狼レビューを待つこと。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-001.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-001.md
@@ -22,7 +22,26 @@ feature/ABC-GN-valuation-excess-260724-v0
 
 ただし、ABC 予想そのものを証明したという主張へ進まない。
 
-## 2. 最初の調査
+## 2. 並行作業の認識
+
+現在、同じ `develop` から派生した次の FLT7 branch が並行して進行している。
+
+```text
+wip/FLT7-magic-core-260722-WiseWolf
+```
+
+今回の ABC–GN checkpoint はこれと独立に進める。
+
+- `DkMath/FLT/Seven/**` と FLT7 専用 docs を変更しない。
+- FLT7 branch を merge / cherry-pick / rebase しない。
+- FLT7 側の未統合 theorem を前提にしない。
+- 共有 aggregator を触る場合は最小変更とし、変更理由を report に書く。
+- 共有ファイルに予期しない差分が見える場合は、それを消したり整理したりせず停止し、report に記録する。
+- ABC–GN の theorem が一般数論層に属する場合でも、FLT7 専用実装への依存は作らない。
+
+対象領域を守る限り、両 branch は独立に開発できる。競合解決を今回の仕事へ含めない。
+
+## 3. 最初の調査
 
 次を読み、実在する定義・定理・import 方向を確認する。
 
@@ -50,7 +69,7 @@ padicValNat の積・冪・非零条件 API
 
 既存 theorem がある場合は再証明しない。
 
-## 3. 第一 checkpoint の数学目標
+## 4. 第一 checkpoint の数学目標
 
 ABC triple `a + b = c`, `Nat.Coprime a b` と指数 `n` から、次の加法分解を ABC 側で再利用可能な形へ固定する。
 
@@ -76,7 +95,7 @@ gcd(a * GN n a b, b^n) = 1
 
 これは `gcd(a,b)=1` と、`GN n a b mod b` の既存評価から導ける可能性がある。current API を調査し、最短の証明を選ぶこと。
 
-## 4. 推奨する実装面
+## 5. 推奨する実装面
 
 第一候補:
 
@@ -92,7 +111,6 @@ API の候補は次だが、既存 `Triple` の field 名・constructor・namesp
 namespace DkMath.ABC
 
 noncomputable def Triple.gnPowerLift ... : Triple := ...
-
 theorem Triple.gnPowerLift_left_eq ...
 theorem Triple.gnPowerLift_right_eq ...
 theorem Triple.gnPowerLift_terminal_eq ...
@@ -112,7 +130,7 @@ ABC triple
   -> coprime certificate
 ```
 
-## 5. 余力がある場合のみ
+## 6. 余力がある場合のみ
 
 第一 checkpoint がきれいに閉じた場合だけ、ABC 座標で次の valuation 分解を薄い wrapper として追加してよい。
 
@@ -126,7 +144,7 @@ primitive prime の場合に境界側 valuation が消える既存 theorem が�
 
 この余力項が import や非零条件で膨らむ場合は、実装せず調査結果だけ `report-001.md` に残す。
 
-## 6. 禁止範囲
+## 7. 禁止範囲
 
 この checkpoint では次を行わない。
 
@@ -143,7 +161,7 @@ FLT module への接続
 
 新しい `axiom`、`sorry`、`native_decide` を追加しない。
 
-## 7. Public import
+## 8. Public import
 
 新 module を追加した場合、どの aggregator から公開すべきかを調査する。
 
@@ -151,7 +169,7 @@ FLT module への接続
 
 公開しない判断をした場合は、その理由を report に書く。
 
-## 8. 検証
+## 9. 検証
 
 最低限、変更対象を含む適切な `lake build` を実行する。
 
@@ -159,7 +177,7 @@ FLT module への接続
 
 既知の unrelated warning は修正対象にしない。
 
-## 9. 報告
+## 10. 報告
 
 次を作成する。
 
@@ -178,9 +196,10 @@ lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
 6. build 結果
 7. 次の最小 checkpoint 候補
 8. commit SHA
+9. 並行 FLT7 branch と共有領域を触れたか
 ```
 
-## 10. 終了条件
+## 11. 終了条件
 
 次のいずれかで停止する。
 

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-002.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-002.md
@@ -1,0 +1,224 @@
+# Codex Instruction 002
+
+Theme: ABC 座標における p-adic boundary / GN valuation split
+
+作業 branch:
+
+```text
+wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+## 1. 現在地
+
+Checkpoint 001 では、次の GN power lift が完成した。
+
+```lean
+DkMath.ABC.Triple.gnPowerLift
+DkMath.ABC.Triple.gnPowerLift_sum
+DkMath.ABC.Triple.gnPowerLift_coprime
+```
+
+数学的には、任意の `T : Triple` と `n : ℕ` に対して、
+
+$$T.a\,GN_n(T.a,T.b)+T.b^n=T.c^n$$
+
+が additive coprime triple として固定された。
+
+Checkpoint 002 では、この恒等式へ `padicValNat` を作用させ、境界 `T.a` と kernel `GN n T.a T.b` の valuation を ABC namespace から再利用できる薄い bridge として固定する。
+
+## 2. 調査対象
+
+GitHub repository 内の current source だけを参照する。
+
+最初に次を確認する。
+
+```text
+lean/dk_math/DkMath/ABC/GNPowerLift.lean
+lean/dk_math/DkMath/ABC/Triple.lean
+lean/dk_math/DkMath/ABC/PadicValNat.lean
+lean/dk_math/DkMath/NumberTheory/Gcd/GN.lean
+lean/dk_math/DkMath/NumberTheory/GcdNext.lean
+lean/dk_math/DkMath/CosmicFormula/CosmicFormulaBinom.lean
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
+```
+
+特に次の実在 API を再確認する。
+
+```text
+cosmic_id_csr'
+GN_ne_zero_nat_of_two_le
+padicValNat.mul
+padicValNat.eq_zero_of_not_dvd
+DkMath.NumberTheory.GcdNext.padicValNat_factorization
+padicValNat_sub_pow_eq_padicValNat_GN_of_not_dvd_gap
+```
+
+既存 theorem で十分な場合は再証明せず、ABC 座標 wrapper に徹する。
+
+## 3. 主目標
+
+推奨する新規 module:
+
+```text
+lean/dk_math/DkMath/ABC/GNValuationSplit.lean
+```
+
+ただし current import 構造上、より薄い配置がある場合は現場判断してよい。
+
+### 3.1. 差冪の factorization
+
+正の ABC triple 座標と `2 ≤ n` のもとで、次を固定する。
+
+$$T.c^n-T.b^n=T.a\,GN_n(T.a,T.b)$$
+
+候補 theorem shape:
+
+```lean
+theorem Triple.powerDiff_eq_boundary_mul_GN
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n)
+    (ha : 0 < T.a) :
+    T.c ^ n - T.b ^ n = T.a * GN n T.a T.b := by
+  ...
+```
+
+`hn` が不要なら削ってよい。statement は実際に必要な最小仮定へ調整する。
+
+### 3.2. p-adic valuation split
+
+少なくとも次の意味を持つ theorem を追加する。
+
+$$v_q(T.c^n-T.b^n)=v_q(T.a)+v_q\!\left(GN_n(T.a,T.b)\right)$$
+
+候補 theorem shape:
+
+```lean
+theorem Triple.padic_powerDiff_eq_boundary_add_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n)
+    (ha : 0 < T.a)
+    (hb : 0 < T.b)
+    (hq : Nat.Prime q) :
+    padicValNat q (T.c ^ n - T.b ^ n) =
+      padicValNat q T.a +
+        padicValNat q (GN n T.a T.b) := by
+  ...
+```
+
+既存 API が要求する非零条件を、`ha`, `hb`, `hn` から局所的に構成する。
+
+既存の positive triple packet が自然に利用できる場合は使ってよい。存在しない場合、この checkpoint のためだけに新しい structure は作らず、仮定を明示する。
+
+### 3.3. boundary が消える specialization
+
+`q ∤ T.a` の場合、boundary valuation を消して次を得る。
+
+$$v_q(T.c^n-T.b^n)=v_q\!\left(GN_n(T.a,T.b)\right)$$
+
+候補 theorem shape:
+
+```lean
+theorem Triple.padic_powerDiff_eq_GN_of_not_dvd_boundary
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n)
+    (ha : 0 < T.a)
+    (hb : 0 < T.b)
+    (hq : Nat.Prime q)
+    (hq_boundary : ¬ q ∣ T.a) :
+    padicValNat q (T.c ^ n - T.b ^ n) =
+      padicValNat q (GN n T.a T.b) := by
+  ...
+```
+
+これは primitive-prime wrapper より一般の局所 theorem とする。
+
+## 4. 追加してよい補助 API
+
+証明が自然になる場合、lifted triple の左座標に直接作用する wrapper を追加してよい。
+
+```lean
+theorem Triple.padic_gnPowerLift_a_eq_boundary_add_GN ...
+```
+
+また、primitive prime の既存 witness から `¬ q ∣ T.a` を即座に得られる薄い wrapper が既存 import 境界内で簡潔に閉じる場合のみ追加してよい。
+
+primitive API の接続が膨らむ場合は実装せず、利用可能な theorem 名と必要仮定を `report-002.md` に記録する。
+
+## 5. 境界
+
+この checkpoint では次を行わない。
+
+```text
+q ∣ n / q ∤ n の exceptional layer 定義
+GNValuationExcess の定義
+Real.log / rad identity
+high-lift prime の排除
+ABC quality との接続
+abc_main_axiom の変更・利用
+確率・Janson・Borel–Cantelli 層の変更
+FLT7 への接続
+共有 module の大規模 refactor
+```
+
+新しい `axiom`、`sorry`、`native_decide` は追加しない。
+
+`DkMath/FLT/Seven/**`、FLT7 専用 docs、`wip/FLT7-magic-core-260722-WiseWolf` は参照・変更・統合対象ではない。
+
+## 6. Public import
+
+新 module を無理に aggregator へ追加しない。
+
+この checkpoint では、直接、
+
+```lean
+import DkMath.ABC.GNValuationSplit
+```
+
+で利用可能なら十分である。
+
+共有 aggregator の変更が数学的に必要な場合のみ最小変更とし、理由を report に記録する。
+
+## 7. 実装内検証
+
+対象 module のローカル build を行い、実装が Lean に認可されるところまで確認する。
+
+GitHub の commit、push、PR 操作、CI 起動・確認は行わない。それらは User の受け渡し工程である。
+
+## 8. 実装報告
+
+次を作成する。
+
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
+```
+
+最低限、次を記録する。
+
+```text
+- 再利用した実在 API
+- 追加・変更した module
+- 新規 theorem surface
+- 各 theorem の正確な仮定
+- 非零条件をどう構成したか
+- primitive wrapper を実装したか、見送ったか
+- ローカル build 結果
+- FLT7 / 共有領域を変更していないこと
+- 次 checkpoint 候補
+```
+
+## 9. 停止条件
+
+```text
+Outcome A:
+  full valuation split と non-boundary specialization が完成した。
+
+Outcome B:
+  factorization は完成したが、padicValNat の非零条件または import 境界に不足 API がある。
+  不足する最小 theorem shape を report に固定した。
+
+Outcome C:
+  既存 API に同等 theorem があり、新 module がほぼ重複になる。
+  最薄 wrapper または新規実装不要という判断を report に固定した。
+```
+
+どの Outcome でも、実装・ローカル検証・`report-002.md` 作成後に停止し、User へ結果を返す。次 checkpoint へ自動進行しない。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-003.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-003.md
@@ -1,0 +1,236 @@
+# Codex Instruction 003
+
+Theme: ABC 座標における exponent-exception / non-exceptional GN layer
+
+作業 branch:
+
+```text
+wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+## 1. 現在地
+
+Checkpoint 001 では GN power lift、Checkpoint 002 では p-adic boundary / GN split が完成した。
+
+```lean
+DkMath.ABC.Triple.gnPowerLift
+DkMath.ABC.Triple.powerDiff_eq_boundary_mul_GN
+DkMath.ABC.Triple.padic_powerDiff_eq_boundary_add_GN
+DkMath.ABC.Triple.padic_powerDiff_eq_GN_of_not_dvd_boundary
+```
+
+数学的には、正の ABC triple と `2 ≤ n` のもとで、
+
+$$v_q(T.c^n-T.b^n)=v_q(T.a)+v_q\!\left(GN_n(T.a,T.b)\right)$$
+
+が固定された。
+
+Checkpoint 003 は研究地図 `ABC-GN-004` に対応する。境界 `T.a` と kernel `GN n T.a T.b` の共通 prime は指数 `n` を割る、という gcd spine を ABC namespace へ固定し、`q ∤ n` の non-exceptional channel では valuation が GN 側へ集中することを theorem surface として得る。
+
+## 2. 調査対象
+
+GitHub repository 内の current source だけを参照する。
+
+```text
+lean/dk_math/DkMath/ABC/GNPowerLift.lean
+lean/dk_math/DkMath/ABC/GNValuationSplit.lean
+lean/dk_math/DkMath/ABC/Triple.lean
+lean/dk_math/DkMath/NumberTheory/Gcd/GN.lean
+lean/dk_math/DkMath/NumberTheory/UniqueFactorizationGN.lean
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
+```
+
+特に次の実在 API を再確認する。
+
+```text
+DkMath.NumberTheory.Gcd.gcd_gap_GN_dvd_exp
+DkMath.NumberTheory.Gcd.coprime_boundary_GN_of_coprime_add_of_coprime_exp
+DkMath.NumberTheory.PrimePowComparisonExceptionalLayer
+DkMath.NumberTheory.PrimePowComparisonNonExceptionalLayer
+Triple.padic_powerDiff_eq_GN_of_not_dvd_boundary
+```
+
+`UniqueFactorizationGN` は既存 vocabulary と theorem surface の確認対象である。依存が重い場合、この ABC module から import せず、`Gcd.GN` の最小 API だけで実装する。
+
+## 3. 推奨 module
+
+```text
+lean/dk_math/DkMath/ABC/GNExceptionalSplit.lean
+```
+
+current import 構造上、より薄い配置・名称がある場合は現場判断してよい。
+
+## 4. 主目標
+
+### 4.1. ABC boundary / GN gcd は指数を割る
+
+次の意味を持つ ABC wrapper を追加する。
+
+$$\gcd\!\left(T.a,GN_n(T.a,T.b)\right)\mid n$$
+
+候補 theorem shape:
+
+```lean
+theorem Triple.gcd_boundary_GN_dvd_exp
+    (T : Triple) {n : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a) :
+    Nat.gcd T.a (GN n T.a T.b) ∣ n := by
+  ...
+```
+
+`T.hsum` から `T.b < T.c` を作り、`T.hcop` から `Nat.Coprime T.c T.b` を作って、既存 `gcd_gap_GN_dvd_exp` を ABC 座標へ移すことを第一候補とする。
+
+仮定がさらに削れる場合は最小化してよい。
+
+### 4.2. boundary / GN overlap は指数例外を強制する
+
+prime に限定する前の一般 divisibility theorem を優先する。
+
+```lean
+theorem Triple.dvd_exp_of_dvd_boundary_of_dvd_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a)
+    (hq_boundary : q ∣ T.a)
+    (hq_GN : q ∣ GN n T.a T.b) :
+    q ∣ n := by
+  ...
+```
+
+これは、任意の共通因子が gcd を経由して指数を割るという局所 Core である。
+
+### 4.3. non-exceptional channel の boundary separation
+
+`q ∤ n` かつ `q ∣ GN` なら、`q ∤ T.a` を得る。
+
+```lean
+theorem Triple.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a)
+    (hq_exp : ¬ q ∣ n)
+    (hq_GN : q ∣ GN n T.a T.b) :
+    ¬ q ∣ T.a := by
+  ...
+```
+
+定理名と引数順は existing style に合わせて調整してよい。
+
+### 4.4. non-exceptional GN valuation concentration
+
+Checkpoint 002 の specialization と 4.3 を接続し、prime `q` が GN に現れ、指数を割らない場合、差冪 valuation 全体が GN 側へ集中する theorem を追加する。
+
+$$q\nmid n,\ q\mid GN_n(T.a,T.b)\Longrightarrow v_q(T.c^n-T.b^n)=v_q\!\left(GN_n(T.a,T.b)\right)$$
+
+候補 theorem shape:
+
+```lean
+theorem Triple.padic_powerDiff_eq_GN_of_not_dvd_exp_of_dvd_GN
+    (T : Triple) {n q : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hq : Nat.Prime q)
+    (hq_exp : ¬ q ∣ n)
+    (hq_GN : q ∣ GN n T.a T.b) :
+    padicValNat q (T.c ^ n - T.b ^ n) =
+      padicValNat q (GN n T.a T.b) := by
+  ...
+```
+
+この theorem は primitive prime を仮定せず、non-exceptional GN support 上の一般局所 bridge とする。
+
+### 4.5. coprime exponent wrapper
+
+既存 theorem の薄い ABC wrapper として自然に閉じる場合、次も追加してよい。
+
+```lean
+theorem Triple.coprime_boundary_GN_of_coprime_exp
+    (T : Triple) {n : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a)
+    (hcop_exp : Nat.Coprime T.a n) :
+    Nat.Coprime T.a (GN n T.a T.b) := by
+  ...
+```
+
+これは 4.1 の全体版であり、既存 `coprime_boundary_GN_of_coprime_add_of_coprime_exp` の ABC 座標 wrapper に徹する。
+
+## 5. 設計判断
+
+新しい `GNExceptionalPrime` / `GNNonExceptionalPrime` predicate は必須ではない。既存 `q ∣ n` / `¬ q ∣ n` の theorem assumptions と `UniqueFactorizationGN` の vocabulary で十分なら、重複定義を追加しない。
+
+一般数論定理を ABC 側で再証明しない。ABC module の役割は、`T.a + T.b = T.c` と `T.hcop` を既存 GN gcd API へ接続する薄い翻訳層である。
+
+## 6. 境界
+
+この checkpoint では次を行わない。
+
+```text
+prime-power comparison family の新規構築
+GNValuationExcess の定義
+factorization support の有限和
+Real.log / rad identity
+primitive / Zsigmondy witness の接続
+high-lift prime の排除
+ABC quality との接続
+abc_main_axiom の変更・利用
+FLT7 への接続
+共有 module の大規模 refactor
+```
+
+新しい `axiom`、`sorry`、`native_decide` は追加しない。
+
+`DkMath/FLT/Seven/**`、FLT7 専用 docs、`wip/FLT7-magic-core-260722-WiseWolf` は参照・変更・統合対象ではない。
+
+## 7. Public import
+
+新 module を無理に aggregator へ追加しない。
+
+```lean
+import DkMath.ABC.GNExceptionalSplit
+```
+
+で利用可能なら十分である。共有 aggregator の変更が必要な場合のみ最小変更とし、理由を report に記録する。
+
+## 8. 実装内検証
+
+対象 module のローカル build を行い、実装が Lean に認可されるところまで確認する。
+
+GitHub の commit、push、PR 操作、CI 起動・確認は行わない。それらは User の受け渡し工程である。
+
+## 9. 実装報告
+
+次を作成する。
+
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-003.md
+```
+
+最低限、次を記録する。
+
+```text
+- 再利用した実在 API
+- 追加・変更した module
+- 新規 theorem surface
+- gcd spine の正確な仮定
+- non-exceptional separation の証明経路
+- valuation concentration theorem の正確な仮定
+- `UniqueFactorizationGN` を import したか、避けたか、その理由
+- ローカル build 結果
+- FLT7 / 共有領域を変更していないこと
+- 次 checkpoint 候補
+```
+
+## 10. 停止条件
+
+```text
+Outcome A:
+  gcd boundary/GN divides exponent、overlap forces exception、
+  non-exceptional boundary separation、valuation concentration が完成した。
+
+Outcome B:
+  gcd spine と separation は完成したが、valuation wrapper の import または
+  仮定整合に不足 API がある。最小 blocker を report に固定した。
+
+Outcome C:
+  current source に同等 theorem が既に存在し、ABC wrapper だけで十分だった。
+  最薄 theorem surface と重複回避判断を report に固定した。
+```
+
+どの Outcome でも、実装・ローカル検証・`report-003.md` 作成後に停止し、User へ結果を返す。次 checkpoint へ自動進行しない。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-003.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-003.md
@@ -233,4 +233,5 @@ Outcome C:
   最薄 theorem surface と重複回避判断を report に固定した。
 ```
 
-どの Outcome でも、実装・ローカル検証・`report-003.md` 作成後に停止し、User へ結果を返す。次 checkpoint へ自動進行しない。
+どの Outcome でも、実装・ローカル検証・`report-003.md` 作成後に停止し、User へ結果を返す。
+次 checkpoint へ自動進行しない。※ただし、ユーザーの意向を最優先とする。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-004.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-004.md
@@ -1,0 +1,391 @@
+# Codex Instruction 004
+
+Theme: close the unconditional GN return bound and identify valuation excess with high-lift carriers
+
+作業 branch:
+
+```text
+wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+## 1. Review correction and current frontier
+
+The current branch has Lean-checked implementations for:
+
+```text
+ABC-GN-004  exponent-exception / non-exceptional split
+ABC-GN-005  exact log-rad-plus-excess identity
+ABC-GN-006  conditional quality-to-excess interface
+ABC-GN-007  local high-lift API
+```
+
+The code review accepts the new theorem surfaces in:
+
+```text
+DkMath/ABC/GNExceptionalSplit.lean
+DkMath/ABC/GNValuationExcess.lean
+DkMath/ABC/GNHighLift.lean
+DkMath/ABC/GNQualityExcessBridge.lean
+```
+
+However, `report-004.md` is too pessimistic in treating both
+`GNReturnLowerBound` and `GNSupportBudget` as equally open global obligations.
+
+For an ABC triple `T.a + T.b = T.c`, the GN kernel is the difference quotient
+
+```text
+GN n T.a T.b = (T.c^n - T.b^n) / T.a
+```
+
+and contains the endpoint term `T.c^(n-1)`.  Therefore the next task is to
+close, without an extra global hypothesis,
+
+```text
+T.c^(n-1) ≤ GN n T.a T.b
+```
+
+and hence
+
+```text
+(n-1) * log T.c ≤ log (GN n T.a T.b).
+```
+
+After this is proved, the genuine global obligation remaining in the
+quality-to-excess route is the GN support budget.
+
+## 2. Sources to inspect
+
+Use only repository current source.
+
+```text
+lean/dk_math/DkMath/ABC/GNPowerLift.lean
+lean/dk_math/DkMath/ABC/GNValuationSplit.lean
+lean/dk_math/DkMath/ABC/GNValuationExcess.lean
+lean/dk_math/DkMath/ABC/GNHighLift.lean
+lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
+lean/dk_math/DkMath/Algebra/DiffPow.lean
+lean/dk_math/DkMath/NumberTheory/Gcd/GN.lean
+lean/dk_math/DkMath/CosmicFormula/CosmicFormulaBinom.lean
+lean/dk_math/DkMath/ABC/RadLogBasic.lean
+lean/dk_math/DkMath/ABC/AnalyticQualityBridge.lean
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-004.md
+```
+
+Relevant existing APIs include, but are not limited to:
+
+```text
+Triple.gnPowerLift_sum
+Triple.powerDiff_eq_boundary_mul_GN
+DkMath.Algebra.DiffPow.diffPowSum
+DkMath.Algebra.DiffPow.pow_sub_pow_nat
+DkMath.NumberTheory.Gcd.gn_sub_eq_sd_int
+GN_eq_sum
+log_GN_eq_log_rad_add_GNValuationExcess
+padicValNat_le_iff_dvd
+Real.log_le_log
+Real.log_pow
+```
+
+Choose the lightest proof route.  Do not import a heavy research module merely
+because it contains a theorem with a nearby statement.
+
+## 3. Goal A: unconditional GN return in natural coordinates
+
+Add the smallest natural-number theorem proving the endpoint lower bound.
+A candidate surface is:
+
+```lean
+theorem Triple.pow_pred_c_le_GN
+    (T : Triple) {n : ℕ}
+    (hn : 1 ≤ n) (ha : 0 < T.a) :
+    T.c ^ (n - 1) ≤ GN n T.a T.b := by
+  ...
+```
+
+Adjust assumptions and naming to current style.  `T.hsum` may be used to
+rewrite `T.c = T.a + T.b`.
+
+Preferred mathematical routes:
+
+```text
+Route 1:
+  identify GN with the finite difference-power sum
+  and retain its i = 0 term T.c^(n-1)
+
+Route 2:
+  use a * GN + b^n = c^n
+  prove b^n ≤ b * c^(n-1)
+  rewrite c = a + b
+  cancel the positive factor a
+```
+
+Do not use division on naturals if cancellation or a finite-sum proof is
+cleaner.
+
+If the same current-source representation makes it inexpensive, also prove
+the calibration upper bound
+
+```lean
+GN n T.a T.b ≤ n * T.c ^ (n - 1)
+```
+
+but this upper bound is optional.  It must not delay the lower-bound theorem.
+
+## 4. Goal B: discharge `GNReturnLowerBound`
+
+From Goal A, prove the logarithmic return theorem under positive ABC
+coordinates and `2 ≤ n`.
+
+Candidate surfaces:
+
+```lean
+theorem Triple.log_c_mul_pred_le_log_GN
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) :
+    (((n - 1 : ℕ) : ℝ) * Real.log (T.c : ℝ)) ≤
+      Real.log ((GN n T.a T.b : ℕ) : ℝ) := by
+  ...
+```
+
+```lean
+theorem Triple.gnReturnLowerBound_pred
+    (T : Triple) {n : ℕ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNReturnLowerBound T n ((n - 1 : ℕ) : ℝ) := by
+  ...
+```
+
+Use exact current Mathlib theorem names for casts, powers, and logarithms.
+Keep the lower bound non-strict.
+
+## 5. Goal C: remove avoidable positivity hypotheses
+
+Investigate whether positive `T.a` and `T.b` already imply
+
+```lean
+0 < Real.log (rad (T.a * T.b * T.c) : ℝ)
+```
+
+for an ABC triple.  If it closes with a small local proof, add a reusable
+wrapper such as:
+
+```lean
+theorem Triple.log_rad_abc_pos
+    (T : Triple) (ha : 0 < T.a) (hb : 0 < T.b) :
+    0 < Real.log (rad (T.a * T.b * T.c) : ℝ) := by
+  ...
+```
+
+A proof may pass through `1 < rad (a*b*c)` or a prime divisor of the positive
+product.  Reuse existing radical lemmas where available.
+
+If this requires a large unrelated radical refactor, do not perform it.
+Keep the existing explicit `hrad` assumption and report the smallest missing
+lemma shape.
+
+## 6. Goal D: reduce the quality bridge to support budget only
+
+Add a theorem specializing
+`Triple.GNValuationExcess_gt_of_quality_gt` with
+
+```text
+κ = n - 1
+hreturn = Triple.gnReturnLowerBound_pred
+```
+
+The resulting public theorem must not ask the caller for
+`GNReturnLowerBound` or `0 < κ`.
+
+Candidate conclusion:
+
+```lean
+((((n - 1 : ℕ) : ℝ) * (1 + ε) - σ) *
+    Real.log (rad (T.a * T.b * T.c) : ℝ))
+  < GNValuationExcess n T.a T.b
+```
+
+under high quality and `GNSupportBudget T n σ`.
+
+If Goal C succeeds, remove the explicit radical-log positivity assumption as
+well.  Otherwise retain only that one local analytic hypothesis.
+
+### Affine support budget
+
+Finite exceptional absorption will naturally introduce an additive constant.
+Therefore add an affine interface if it keeps the theorem surface clean:
+
+```lean
+def GNSupportBudgetAffine
+    (T : Triple) (n : ℕ) (σ C : ℝ) : Prop :=
+  Real.log (rad (GN n T.a T.b) : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) + C
+```
+
+and prove the corresponding excess lower bound
+
+```text
+(((n-1)*(1+ε)-σ) * log rad(abc)) - C < GNValuationExcess.
+```
+
+The existing `GNSupportBudget` should become the `C = 0` specialization or
+remain as a compatibility wrapper.  Avoid duplicated proof bodies.
+
+## 7. Goal E: identify excess with high-lift carriers
+
+The current `valuationExcess` sum ranges over the entire factorization support,
+but a support prime with valuation exactly one contributes zero.  Connect the
+exact identity from `GNValuationExcess.lean` with the local high-lift API from
+`GNHighLift.lean`.
+
+A recommended placement is `DkMath/ABC/GNHighLift.lean`, since it already
+imports `GNValuationExcess`.  Do not reverse this dependency and create an
+import cycle.
+
+Define a finite high-lift carrier set only if it improves reuse, for example:
+
+```lean
+noncomputable def highLiftSupport (m : ℕ) : Finset ℕ :=
+  m.factorization.support.filter (fun q => q ^ 2 ∣ m)
+```
+
+or a GN-specialized equivalent.
+
+Prove an exact restriction theorem of the form:
+
+```lean
+theorem valuationExcess_eq_sum_highLift
+    {m : ℕ} (hm : m ≠ 0) :
+    valuationExcess m =
+      ∑ q ∈ highLiftSupport m,
+        (((m.factorization q - 1 : ℕ) : ℝ) * Real.log (q : ℝ)) := by
+  ...
+```
+
+Then add GN exceptional and non-exceptional specializations when they are thin:
+
+```text
+GNExceptionalValuationExcess
+  = sum over exceptional high-lift carriers
+
+GNNonExceptionalValuationExcess
+  = sum over non-exceptional high-lift carriers
+```
+
+At minimum prove:
+
+```lean
+no GN high-lift prime -> GNValuationExcess = 0
+```
+
+If the converse
+
+```lean
+0 < GNValuationExcess -> exists a GNHighLiftPrime
+```
+
+closes without a large positivity detour, add it.  Otherwise record the exact
+missing positivity lemma and stop there.
+
+## 8. Quantifier and frontier audit
+
+Do not state a uniform `GNSupportBudget` theorem without proving its exact
+parameter dependencies.
+
+The report must distinguish at least:
+
+```text
+fixed n versus varying n
+σ depending on n versus absolute σ
+additive constant C depending on n and ε
+pointwise budget versus a theorem uniform over all positive ABC triples
+```
+
+The coefficient that matters is the net margin
+
+```text
+((n - 1) * (1 + ε) - σ)
+```
+
+not the existence of an arbitrary pointwise `σ`.
+
+After Goals A–E, the honest global frontier should be stated as:
+
+```text
+unconditional GN return: closed
+valuation excess carriers: exact finite high-lift support
+remaining global obligation: a quantitatively useful affine GNSupportBudget
+```
+
+Do not claim that the support budget, high-lift rarity, finite exceptional
+absorption, `K_ε`, or ABC has been proved.
+
+## 9. Boundaries
+
+Do not perform:
+
+```text
+abc_main_axiom modification or use
+ABC final theorem claims
+uniform high-lift rarity assumptions disguised as lemmas
+false rad(GN) ≤ rad(abc) transport
+probability / Janson / Borel-Cantelli refactors
+primitive / Zsigmondy expansion unless a tiny existing wrapper is essential
+FLT7 edits or imports
+shared aggregator changes unless mathematically necessary
+large renaming or repository-wide refactoring
+```
+
+Add no new `axiom`, `sorry`, or `native_decide`.
+
+`DkMath/FLT/Seven/**`, FLT7 docs, and
+`wip/FLT7-magic-core-260722-WiseWolf` are outside the task.
+
+## 10. Local validation and report
+
+Run local builds for every changed target module.  GitHub commit, push, PR,
+and CI operations are not part of this instruction.
+
+Because `report-004.md` already records the authorized rolling sprint, write
+the result of this instruction to:
+
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
+```
+
+Record:
+
+```text
+- exact theorem surfaces added
+- proof route used for c^(n-1) ≤ GN
+- whether GNReturnLowerBound was fully discharged
+- whether radical-log positivity was internalized
+- pure and affine support-budget theorem surfaces
+- exact high-lift carrier identities
+- quantifier dependencies left on GNSupportBudget
+- local build results
+- files changed
+- confirmation that FLT7 and shared aggregators were untouched
+- the single next mathematical obligation after this checkpoint
+```
+
+## 11. Stop conditions
+
+```text
+Outcome A:
+  unconditional GN return is closed,
+  quality-to-excess depends only on support budget,
+  and valuation excess is exactly restricted to high-lift carriers.
+
+Outcome B:
+  GN return is closed and the reduced quality bridge is complete,
+  but the high-lift finite-sum restriction needs one minimal factorization lemma.
+  Record its exact statement.
+
+Outcome C:
+  the natural GN endpoint lower bound itself is blocked by a representation or
+  cancellation gap.  Record the smallest missing theorem and do not hide it
+  behind a new hypothesis.
+```
+
+After implementation, local validation, and `report-005.md`, return the result
+to User and stop.  Do not start the support-budget proof automatically.

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-005.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-005.md
@@ -1,0 +1,327 @@
+# Codex Instruction 005
+
+Theme: finite exceptional support absorption and lifted-radical growth reduction
+
+作業 branch:
+
+```text
+wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+## 1. Current frontier
+
+The previous checkpoint closed:
+
+```text
+unconditional GN return
+positive ABC radical-log
+pure / affine quality-to-excess bridge
+exact high-lift carrier formula for valuation excess
+```
+
+The only remaining global input in the quality bridge is a quantitatively useful GN support budget.
+
+Do not attack a false or unsupported statement such as
+
+```text
+rad (GN n a b) ≤ rad (a*b*c)
+```
+
+Instead separate the finite exponent-exceptional support from the genuinely new non-exceptional support.
+
+The intended deterministic spine is:
+
+```text
+GN support
+  = exceptional support q | n
+    disjoint union
+    non-exceptional support q ∤ n
+
+exceptional support product | rad n
+non-exceptional GN primes do not divide a*b*c
+
+therefore
+  log rad(GN)
+    ≤ log rad(n) + log(nonExceptionalSupportProduct)
+```
+
+Then connect the non-exceptional product to radical growth of `T.gnPowerLift n`.
+
+## 2. Sources to inspect
+
+Use repository current source only.
+
+```text
+lean/dk_math/DkMath/ABC/GNPowerLift.lean
+lean/dk_math/DkMath/ABC/GNExceptionalSplit.lean
+lean/dk_math/DkMath/ABC/GNValuationExcess.lean
+lean/dk_math/DkMath/ABC/GNHighLift.lean
+lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
+lean/dk_math/DkMath/ABC/Rad.lean
+lean/dk_math/DkMath/ABC/MassBridge.lean
+lean/dk_math/DkMath/ABC/ValuationFlowBridge.lean
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
+```
+
+Relevant current APIs include:
+
+```text
+Triple.dvd_exp_of_dvd_boundary_of_dvd_GN
+Triple.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+Triple.gnPowerLift_coprime
+Triple.gnPowerLift
+mem_support_factorization_iff
+support_prod_log_eq_sum_log
+rad_mul_coprime
+rad_pow_eq_rad
+prime_channel_family_prod_dvd_supportMass
+supportMass_eq_abc_rad
+GNSupportBudgetAffine
+Triple.GNValuationExcess_gt_of_quality_gt_pred_affine
+```
+
+Choose the lightest dependency route.  Do not import large research modules merely for nearby vocabulary.
+
+## 3. Recommended module
+
+```text
+lean/dk_math/DkMath/ABC/GNSupportReturn.lean
+```
+
+A nearby name is acceptable if current dependency structure strongly favors it.
+
+## 4. Goal A: finite exceptional / non-exceptional support partition
+
+Define finite support sets for a GN kernel, for example:
+
+```lean
+def GNExceptionalSupport (n a b : ℕ) : Finset ℕ :=
+  (GN n a b).factorization.support.filter (fun q => q ∣ n)
+
+def GNNonExceptionalSupport (n a b : ℕ) : Finset ℕ :=
+  (GN n a b).factorization.support.filter (fun q => ¬ q ∣ n)
+```
+
+Define their squarefree products if useful:
+
+```lean
+def GNExceptionalSupportProduct (n a b : ℕ) : ℕ :=
+  (GNExceptionalSupport n a b).prod id
+
+def GNNonExceptionalSupportProduct (n a b : ℕ) : ℕ :=
+  (GNNonExceptionalSupport n a b).prod id
+```
+
+Prove the exact support partition and radical product identity:
+
+```text
+GN support = exceptional ∪ non-exceptional
+rad(GN) = exceptionalProduct * nonExceptionalProduct
+```
+
+Use a disjoint filtered partition; do not introduce multiplicity here.
+
+## 5. Goal B: absorb all exceptional GN support into `rad n`
+
+For `1 ≤ n`, prove every member of `GNExceptionalSupport n a b` is prime and divides `n`.  Then prove:
+
+```lean
+GNExceptionalSupportProduct n a b ∣ rad n
+```
+
+or an equivalent natural inequality.
+
+The proof should use the finite prime-channel family API when it is lighter than rebuilding factorization arguments.
+
+Derive the logarithmic exceptional bound:
+
+```text
+log(exceptionalProduct) ≤ log(rad n)
+```
+
+and the full support estimate:
+
+```text
+log(rad(GN n a b))
+  ≤ log(rad n) + log(nonExceptionalProduct n a b)
+```
+
+Handle positivity and zero cases with the smallest honest assumptions.  In the main ABC use case, `2 ≤ n` and positive `a,b` are available.
+
+## 6. Goal C: non-exceptional GN support is fresh relative to the original triple
+
+For a positive ABC triple and `1 ≤ n`, prove that any
+
+```text
+q ∈ GNNonExceptionalSupport n T.a T.b
+```
+
+satisfies:
+
+```text
+Nat.Prime q
+q ∣ GN n T.a T.b
+¬ q ∣ T.a
+¬ q ∣ T.b
+¬ q ∣ T.c
+¬ q ∣ T.a * T.b * T.c
+```
+
+Use:
+
+```text
+q ∤ n + q ∣ GN -> q ∤ T.a
+```
+
+for the boundary, and derive the `b,c` separation from the coprimality of the lifted triple.  Avoid re-proving the general gcd theory.
+
+Package the result as one reusable theorem if that keeps later support proofs short.
+
+## 7. Goal D: embed the fresh product into lifted radical growth
+
+Let
+
+```text
+L := T.gnPowerLift n
+```
+
+Prove that the original ABC radical and the non-exceptional GN support product occur as disjoint support inside the lifted triple radical.  Preferred target:
+
+```lean
+rad (T.a * T.b * T.c) *
+    GNNonExceptionalSupportProduct n T.a T.b ∣
+  rad (L.a * L.b * L.c)
+```
+
+or the corresponding natural inequality.
+
+An exact equality is welcome only if it follows cleanly.  Do not delay the divisibility/lower-bound bridge to force an exact formula.
+
+Then derive the logarithmic growth inequality:
+
+```text
+log(rad(abc)) + log(nonExceptionalProduct)
+  ≤ log(rad(lifted abc))
+```
+
+under the needed positivity assumptions.
+
+## 8. Goal E: replace the full support budget by a lifted-radical-growth budget
+
+Define an affine lifted-radical growth predicate, for example:
+
+```lean
+def GNLiftRadicalGrowthBudgetAffine
+    (T : Triple) (n : ℕ) (σ C : ℝ) : Prop :=
+  Real.log (rad ((T.gnPowerLift n).a *
+      (T.gnPowerLift n).b * (T.gnPowerLift n).c) : ℝ) ≤
+    (1 + σ) * Real.log (rad (T.a * T.b * T.c) : ℝ) + C
+```
+
+Also define a non-exceptional support budget if useful:
+
+```lean
+def GNNonExceptionalSupportBudgetAffine
+    (T : Triple) (n : ℕ) (σ C : ℝ) : Prop :=
+  Real.log (GNNonExceptionalSupportProduct n T.a T.b : ℝ) ≤
+    σ * Real.log (rad (T.a * T.b * T.c) : ℝ) + C
+```
+
+Prove the deterministic chain:
+
+```text
+lifted-radical-growth budget
+  -> non-exceptional support budget
+  -> GNSupportBudgetAffine T n σ (C + log(rad n))
+```
+
+The exact arrangement of additive constants may be normalized algebraically, but the exceptional contribution must be explicit and depend only on `n` through `rad n` or a provably smaller term.
+
+Finally compose with the existing quality bridge to obtain a theorem whose only global transport input is the lifted-radical-growth budget.  Its excess lower bound should visibly pay the exceptional constant `log(rad n)`.
+
+## 9. Mathematical meaning and stopping boundary
+
+This checkpoint should complete `ABC-GN-008` in the following precise sense:
+
+```text
+all q | n support is absorbed into a finite exponent constant;
+all remaining support is fresh relative to the original ABC triple;
+the remaining global obligation is renamed as lifted radical growth
+or non-exceptional support growth.
+```
+
+Do not claim a uniform lifted-radical-growth theorem.
+
+Do not begin:
+
+```text
+Hensel rarity theorems
+p-adic logarithm formalization
+uniform non-exceptional support bounds
+K_epsilon construction
+abc_main_axiom replacement
+probability-layer refactoring
+FLT7 integration
+```
+
+No new `axiom`, `sorry`, or `native_decide`.
+
+## 10. Documentation correction
+
+Update stale module comments in `GNQualityExcessBridge.lean` if inexpensive: the return lower bound is now unconditional, so the genuine remaining input is the support budget rather than two equally open estimates.  Do not refactor theorem names merely for prose consistency.
+
+## 11. Public import
+
+A direct import is sufficient:
+
+```lean
+import DkMath.ABC.GNSupportReturn
+```
+
+Do not modify a shared aggregator unless strictly required.  Record any such change in the report.
+
+## 12. Local validation and report
+
+Run local builds for the new module and directly affected modules.
+
+Create:
+
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
+```
+
+Record:
+
+```text
+- exact support definitions
+- exceptional/non-exceptional partition theorem
+- exceptional product -> rad n proof route
+- freshness theorem relative to a*b*c
+- lifted radical divisibility or inequality
+- exact affine constant transport
+- final quality-to-excess theorem surface
+- remaining global mathematical obligation
+- local build results
+- FLT7/shared-area status
+```
+
+Do not commit, push, edit the PR, start CI, or inspect CI.  Return the result to the User and stop.
+
+## 13. Outcomes
+
+```text
+Outcome A:
+  exceptional absorption, freshness, lifted-radical bridge, and affine
+  composition all close.
+
+Outcome B:
+  exceptional absorption and freshness close, but the lifted-radical product
+  bridge needs one small missing radical/support lemma.  Implement the maximal
+  theorem surface and name the exact missing lemma.
+
+Outcome C:
+  current source already contains a stronger equivalent bridge.  Add only the
+  thinnest ABC wrapper and document the dependency.
+```
+
+In every outcome, stop after implementation, local validation, and `report-006.md`.

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-006.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/instruction-006.md
@@ -1,0 +1,433 @@
+# Codex Instruction 006
+
+Theme: two-budget ABC closure — support growth plus valuation multiplicity
+
+作業 branch:
+
+```text
+wip/ABC-GN-valuation-excess-260724-Codex
+```
+
+## 1. Current frontier
+
+前 checkpoint では、次の deterministic support spine が完成した。
+
+```text
+GN support
+  = exceptional support q | n
+  ⊔ non-exceptional support q ∤ n
+
+exceptional support product | rad n
+
+non-exceptional support is fresh from a*b*c
+
+rad(a*b*c) * nonExceptionalSupportProduct
+  | rad((T.gnPowerLift n).a *
+        (T.gnPowerLift n).b *
+        (T.gnPowerLift n).c)
+
+lifted radical growth budget (σ, Cs)
+  -> GNSupportBudgetAffine T n σ (Cs + log(rad n))
+```
+
+既存層では、さらに次が Lean-confirmed である。
+
+```text
+c^(n-1) ≤ GN n a b
+
+log GN
+  = log(rad GN) + GNValuationExcess
+
+GNValuationExcess
+  = GNExceptionalValuationExcess
+  + GNNonExceptionalValuationExcess
+```
+
+重要な correction:
+
+```text
+lifted-radical growth alone does not prove ABC.
+
+It bounds prime support and therefore gives a lower bound on
+GNValuationExcess under high quality.
+
+A second upper budget on valuation multiplicity is required.
+```
+
+この checkpoint の役目は、一様 budget 自体を証明することではない。
+
+```text
+support budget
++
+valuation-excess budget
+  -> explicit K_epsilon ABC bound
+```
+
+という最終合成を Lean theorem surface として固定し、`abc_main_axiom` を置換するために本当に必要な一様契約を明示する。
+
+## 2. Sources to inspect
+
+repository current source だけを参照する。
+
+```text
+lean/dk_math/DkMath/ABC/GNPowerLift.lean
+lean/dk_math/DkMath/ABC/GNValuationExcess.lean
+lean/dk_math/DkMath/ABC/GNHighLift.lean
+lean/dk_math/DkMath/ABC/GNQualityExcessBridge.lean
+lean/dk_math/DkMath/ABC/GNSupportReturn.lean
+lean/dk_math/DkMath/ABC/ABCMainTheorem.lean
+lean/dk_math/DkMath/ABC/Triple.lean
+lean/dk_math/DkMath/ABC/Rad.lean
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
+```
+
+current theorem names、仮定、namespace を確認し、存在しない名前を写経しない。
+
+特に次の current API を再利用する。
+
+```text
+Triple.log_c_mul_pred_le_log_GN
+Triple.log_GN_eq_log_rad_add_GNValuationExcess
+GNValuationExcess_eq_exceptional_add_nonExceptional
+Triple.GNSupportBudgetAffine_of_liftGrowth
+GNLiftRadicalGrowthBudgetAffine
+GNSupportBudgetAffine
+Triple.log_rad_abc_pos
+```
+
+## 3. Recommended module
+
+```text
+lean/dk_math/DkMath/ABC/GNFinalBudgetBridge.lean
+```
+
+より自然な軽量配置が current dependency structure にある場合は変更してよい。
+
+## 4. Goal A: valuation-excess upper-budget predicates
+
+full valuation excess の affine upper budget を定義する。
+
+```lean
+
+def GNValuationExcessBudgetAffine
+    (T : Triple) (n : ℕ) (τ D : ℝ) : Prop :=
+  GNValuationExcess n T.a T.b ≤
+    τ * Real.log (rad (T.a * T.b * T.c) : ℝ) + D
+```
+
+exceptional / non-exceptional 層についても定義する。
+
+```lean
+
+def GNExceptionalExcessBudgetAffine
+    (T : Triple) (n : ℕ) (τ D : ℝ) : Prop :=
+  GNExceptionalValuationExcess n T.a T.b ≤
+    τ * Real.log (rad (T.a * T.b * T.c) : ℝ) + D
+
+
+def GNNonExceptionalExcessBudgetAffine
+    (T : Triple) (n : ℕ) (τ D : ℝ) : Prop :=
+  GNNonExceptionalValuationExcess n T.a T.b ≤
+    τ * Real.log (rad (T.a * T.b * T.c) : ℝ) + D
+```
+
+既存 exact partition から、次を証明する。
+
+```text
+exceptional budget (τe, De)
++
+non-exceptional budget (τn, Dn)
+
+-> full budget (τe + τn, De + Dn)
+```
+
+候補 theorem:
+
+```lean
+
+theorem GNValuationExcessBudgetAffine.of_split
+    ...
+```
+
+命名は current style に合わせる。
+
+ここでは finite exceptional prime support と valuation multiplicity を混同しない。
+
+```text
+exceptional support product | rad n
+```
+
+だけでは、exceptional valuation depth の一様上界は得られない。
+
+## 5. Goal B: direct logarithmic height upper bound
+
+support budget と excess budget を exact identity へ合流させる。
+
+目標形:
+
+```lean
+
+theorem Triple.log_c_mul_pred_le_of_support_and_excessBudget
+    (T : Triple) {n : ℕ} {σ Cs τ Ce : ℝ}
+    (hn : 2 ≤ n) (ha : 0 < T.a) (hb : 0 < T.b)
+    (hsupport : GNSupportBudgetAffine T n σ Cs)
+    (hexcess : GNValuationExcessBudgetAffine T n τ Ce) :
+    (((n - 1 : ℕ) : ℝ) * Real.log (T.c : ℝ)) ≤
+      (σ + τ) *
+        Real.log (rad (T.a * T.b * T.c) : ℝ) +
+      (Cs + Ce) := by
+  ...
+```
+
+証明経路:
+
+```text
+(n-1) log c ≤ log GN
+log GN = log(rad GN) + valuation excess
+log(rad GN) ≤ σ log R + Cs
+valuation excess ≤ τ log R + Ce
+```
+
+`linarith` / `nlinarith` へ渡せる直線形を維持する。
+
+## 6. Goal C: lifted-growth specialization
+
+`GNSupportReturn.lean` の transport theorem を再利用し、
+
+```text
+GNLiftRadicalGrowthBudgetAffine T n σ Cs
+GNValuationExcessBudgetAffine T n τ Ce
+```
+
+から、次を得る。
+
+```text
+(n-1) log c
+  ≤ (σ + τ) log(rad(a*b*c))
+    + Cs + Ce + log(rad n)
+```
+
+候補 theorem:
+
+```lean
+
+theorem Triple.log_c_mul_pred_le_of_liftGrowth_and_excessBudget
+    ...
+```
+
+exceptional support constant `Real.log (rad n : ℝ)` を消さず、結論上に明示する。
+
+## 7. Goal D: explicit pointwise ABC constant
+
+次の margin 条件を仮定する。
+
+```text
+σ + τ ≤ (n-1) * (1+ε)
+```
+
+明示定数を定義する。
+
+```lean
+
+noncomputable def GNABCConstant
+    (n : ℕ) (Cs Ce : ℝ) : ℝ :=
+  max 1
+    (Real.exp
+      ((Cs + Ce + Real.log (rad n : ℝ)) /
+        ((n - 1 : ℕ) : ℝ)))
+```
+
+current elaboration に適した括弧・cast へ調整してよい。
+同値な、より扱いやすい明示定数へ変更してもよい。
+
+ただし、
+
+```text
+K depends only on:
+  n, Cs, Ce
+
+K does not depend on:
+  T.a, T.b, T.c
+```
+
+を保つ。
+
+次の pointwise theorem を目標とする。
+
+```lean
+
+theorem Triple.abc_bound_of_liftGrowth_and_excessBudget
+    (T : Triple) {n : ℕ} {ε σ Cs τ Ce : ℝ}
+    (hn : 2 ≤ n)
+    (ha : 0 < T.a) (hb : 0 < T.b)
+    (hmargin :
+      σ + τ ≤ ((n - 1 : ℕ) : ℝ) * (1 + ε))
+    (hlift :
+      GNLiftRadicalGrowthBudgetAffine T n σ Cs)
+    (hexcess :
+      GNValuationExcessBudgetAffine T n τ Ce) :
+    (T.c : ℝ) ≤
+      GNABCConstant n Cs Ce *
+        (rad (T.a * T.b * T.c) : ℝ) ^ (1 + ε) := by
+  ...
+```
+
+必要な補助事項:
+
+```text
+0 < T.c
+0 < rad(a*b*c)
+0 < (n-1 : ℝ)
+Real.exp / Real.log
+Real.rpow
+```
+
+既存 API で閉じるものを再証明しない。
+
+`^ (1 + ε)` の elaboration が自然数冪として解釈されないよう、current ABC theorem surface と `Real.rpow` API を確認する。
+
+## 8. Goal E: global final contract
+
+一様契約を structure または Prop として固定する。
+
+候補:
+
+```lean
+
+structure ABCGNFinalBudgetContract (ε : ℝ) where
+  hε : 0 < ε
+  n : ℕ
+  hn : 2 ≤ n
+  σ Cs τ Ce : ℝ
+  margin :
+    σ + τ ≤ ((n - 1 : ℕ) : ℝ) * (1 + ε)
+  liftBudget :
+    ∀ T : Triple, 0 < T.a → 0 < T.b →
+      GNLiftRadicalGrowthBudgetAffine T n σ Cs
+  excessBudget :
+    ∀ T : Triple, 0 < T.a → 0 < T.b →
+      GNValuationExcessBudgetAffine T n τ Ce
+```
+
+これから positive triple 版の global ABC theorem を証明する。
+
+```lean
+
+theorem abc_positive_of_GNFinalBudgetContract
+    {ε : ℝ}
+    (H : ABCGNFinalBudgetContract ε) :
+    ∃ K : ℝ, 1 ≤ K ∧
+      ∀ T : Triple,
+        0 < T.a → 0 < T.b →
+        (T.c : ℝ) ≤
+          K * (rad (T.a * T.b * T.c) : ℝ) ^ (1 + ε) := by
+  ...
+```
+
+自然に閉じる場合は `a = 0` / `b = 0` の coprime endpoint を処理し、現行 `abc_main_axiom` と同じ生引数 surface への bridge を追加してよい。
+
+ただし、この checkpoint では `abc_main_axiom` 自体を削除・変更しない。
+
+## 9. Goal F: audit the actual remaining mathematics
+
+report では、次を明確に区別する。
+
+```text
+proved in Lean:
+  support budget + valuation-excess budget
+    -> explicit K_epsilon ABC bound
+
+not proved:
+  uniform lifted-radical growth budget
+  uniform exceptional valuation-excess budget
+  uniform non-exceptional valuation-excess budget
+```
+
+特に、
+
+```text
+finite exceptional prime support
+```
+
+と、
+
+```text
+uniformly bounded exceptional valuation multiplicity
+```
+
+を混同しない。
+
+固定された有限個の prime であっても、valuation depth が一様定数になるとは限らない。
+
+## 10. Mathematical meaning and stopping boundary
+
+この checkpoint が Outcome A で閉じれば、`abc_main_axiom` の内容は次の三つの一様 budget へ還元される。
+
+```text
+uniform lifted-radical support growth
+uniform exceptional valuation excess
+uniform non-exceptional valuation excess
+```
+
+これは ABC 予想自体の証明ではない。
+
+次を開始しない。
+
+```text
+Hensel rarity theorem
+p-adic logarithm formalization
+LTE の新規大規模構築
+uniform high-lift exclusion
+abc_main_axiom の削除
+FLT7
+確率・密度 route
+```
+
+新規 `axiom`、`sorry`、`native_decide` は追加しない。
+
+## 11. Validation and report
+
+対象 module をローカル build する。
+
+次を作成する。
+
+```text
+lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-007.md
+```
+
+report には最低限、次を記録する。
+
+```text
+- budget predicate の正確な定義
+- exceptional / non-exceptional excess budget の合成
+- support / excess 合成 theorem
+- lifted-growth specialization
+- 明示 K の式
+- pointwise ABC theorem
+- global contract theorem
+- endpoint a=0 / b=0 を扱ったか
+- 残る三つの一様 budget
+- local build
+- axiom audit
+- FLT7 / aggregator の変更有無
+```
+
+## 12. Stop condition
+
+```text
+Outcome A:
+  support budget と valuation-excess budget から
+  明示 K_epsilon を持つ ABC bound が完成した。
+
+Outcome B:
+  logarithmic height bound は完成したが、
+  Real.exp / Real.rpow の pointwise wrapper に最小 blocker が残った。
+
+Outcome C:
+  current source に同等の final contract が既にあり、
+  最薄 wrapper と audit のみで閉じた。
+```
+
+実装・ローカル検証・`report-007.md` 作成後、User へ返して停止する。
+
+commit、push、PR、CI、次 checkpoint への自動進行は行わない。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
@@ -1,0 +1,159 @@
+# ABC–GN Checkpoint 001 Report
+
+作成日: 2026-07-24
+
+Outcome: A
+
+## 1. 調査で見つかった既存 API
+
+- `DkMath.ABC.Triple`
+  - `Triple` は `a`, `b`, `c`, `hsum : a + b = c`,
+    `hcop : Nat.Coprime a b` を持つ。
+- `DkMath.CosmicFormulaBinom`
+  - `GN` は canonical `DkMath.CosmicFormula.GN` への compatibility wrapper。
+  - `cosmic_id_csr'` が任意の `CommSemiring` 上で
+    `(x + u) ^ d = x * GN d x u + u ^ d` を与える。
+- `DkMath.NumberTheory.Gcd.GN`
+  - `gcd_gap_GN_dvd_exp`
+  - `coprime_boundary_GN_of_coprime_add_of_coprime_exp`
+  - `coprime_gap_GN_of_not_dvd_exp_prime`
+  - `padicValNat_sub_pow_eq_padicValNat_GN_of_not_dvd_gap`
+- `DkMath.NumberTheory.PrimitiveBeam`
+  - primitive prime から `GN` divisibility へ移す既存 bridge がある。
+- `DkMath.NumberTheory.UniqueFactorizationGN`
+  - boundary / kernel 分離と `padicValNat.mul` wrapper が既にある。
+- `DkMath.ABC.MassBridge`
+  - `supportMass = rad` と prime-channel family からの support 下界がある。
+- `DkMath.ABC.ValuationFlowBridge`
+  - primitive witness family から `supportMass` / `rad` 下界へ接続する。
+- `DkMath.Petal.ABCBridge`
+  - Petal label support から `rad (GN d x u)` 下界へ接続する。
+- `padicValNat`
+  - 積公式 `padicValNat.mul` は両因子の非零条件を要求する。
+  - 冪公式は `DkMath.ABC.padicValNat_pow` から利用できる。
+
+root の指示候補にあった `SUMMARY.md` は current branch に存在しなかった。
+current source と上記 module を優先して調査した。
+
+## 2. 追加した file と API
+
+追加:
+
+```text
+DkMath/ABC/GNPowerLift.lean
+```
+
+新規 API:
+
+```text
+DkMath.ABC.Triple.gnPowerLift
+DkMath.ABC.Triple.gnPowerLift_a
+DkMath.ABC.Triple.gnPowerLift_b
+DkMath.ABC.Triple.gnPowerLift_c
+DkMath.ABC.Triple.gnPowerLift_sum
+DkMath.ABC.Triple.gnPowerLift_coprime
+```
+
+`gnPowerLift` の座標は次である。
+
+```text
+a := T.a * GN n T.a T.b
+b := T.b ^ n
+c := T.c ^ n
+```
+
+## 3. 数学的に閉じたこと
+
+任意の `T : Triple` と `n : ℕ` に対して、次を Lean で閉じた。
+
+```text
+T.a * GN n T.a T.b + T.b ^ n = T.c ^ n
+Nat.Coprime (T.a * GN n T.a T.b) (T.b ^ n)
+```
+
+したがって、この三座標は再び `Triple` を構成する。指数 `n = 0` も
+含めて仮定なしで成立する。
+
+coprime certificate は `GN mod b` を再証明せず、次の短い経路で得た。
+
+```text
+Coprime a b
+  -> Coprime (a + b) b
+  -> Coprime c b
+  -> Coprime (c ^ n) (b ^ n)
+  -> Coprime (a * GN n a b) (b ^ n)
+```
+
+最後の段は GN 加法恒等式と gcd の加法不変性を使う。
+
+## 4. 再利用した theorem
+
+- `DkMath.CosmicFormulaBinom.cosmic_id_csr'`
+- `Nat.coprime_add_self_left`
+- `Nat.Coprime.pow`
+- `Triple.hsum`
+- `Triple.hcop`
+
+一般 gcd / primitive / valuation module は API frontier の調査対象としたが、
+今回の最短証明には import しなかった。
+
+## 5. 実装しなかった候補と理由
+
+- ABC 座標の `padicValNat` 分解:
+  - 積公式には `a ≠ 0` と `GN n a b ≠ 0` が必要で、power lift 本体には
+    不要な positivity / nonzero 仮定が増える。
+  - instruction 001 の余力項であり、次 checkpoint で必要な statement shape
+    と一緒に設計する方が薄い。
+- primitive prime の境界 valuation 消滅 wrapper:
+  - 既存の `Gcd.GN` と `ValuationFlowBridge` に一般形があり、今回重複する
+    ABC wrapper は追加しなかった。
+- aggregator import:
+  - `DkMath.ABC` / `DkMath.ABC.Main` は解析・公理層まで含む重い入口である。
+  - 循環と不要依存を避け、今回は
+    `import DkMath.ABC.GNPowerLift` を最薄の公開面とした。
+- ABC quality、valuation excess、`abc_main_axiom` 除去:
+  - checkpoint 001 の禁止範囲なので扱っていない。
+
+## 6. 検証結果
+
+局所 build:
+
+```text
+lake build DkMath.ABC.GNPowerLift
+Build completed successfully (8262 jobs).
+```
+
+差分監査:
+
+```text
+git diff --check
+```
+
+新 module に `axiom`, `sorry`, `native_decide` はない。
+
+GitHub Lean CI は branch push により起動する。report 作成時点では未実行。
+
+## 7. 次の最小 checkpoint 候補
+
+次 checkpoint へは自動で進まない。賢狼レビュー後の候補は、lifted triple の
+両座標が非零となる正確な条件を固定し、その条件下で
+
+```text
+padicValNat q (c ^ n - b ^ n)
+  = padicValNat q a + padicValNat q (GN n a b)
+```
+
+を ABC 座標 wrapper として既存積公式へ接続することである。
+
+## 8. Commit
+
+実装 commit:
+
+```text
+742f2294 feat: add ABC GN power lift
+```
+
+## 9. 並行 FLT7 branch / 共有領域
+
+`DkMath/FLT/Seven/**`、FLT7 専用 docs、FLT module、共有 aggregator は
+変更していない。変更対象は新規 ABC module と本 report のみである。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-001.md
@@ -131,7 +131,18 @@ git diff --check
 
 新 module に `axiom`, `sorry`, `native_decide` はない。
 
-GitHub Lean CI は branch push により起動する。report 作成時点では未実行。
+GitHub Lean CI:
+
+```text
+PR #67
+Lean CI run #240
+final conclusion: success
+```
+
+初回 attempt は Mathlib cache setup 中の `leantar` download が
+`curl: (35) Recv failure: Connection reset by peer` で失敗し、Lean build
+自体は skipped だった。同じ run の failed job を再実行し、full build は
+成功した。
 
 ## 7. 次の最小 checkpoint 候補
 

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-002.md
@@ -1,0 +1,203 @@
+# ABC–GN Checkpoint 002 Report
+
+作成日: 2026-07-24
+
+Outcome: A
+
+## 1. 再利用した実在 API
+
+- `DkMath.ABC.Triple.gnPowerLift_sum`
+  - `T.a * GN n T.a T.b + T.b ^ n = T.c ^ n`
+- `DkMath.CosmicFormulaBinom.GN_ne_zero_nat_of_two_le`
+  - `2 ≤ n`, `0 < a`, `0 < b` から `GN n a b ≠ 0`
+- `padicValNat.mul`
+  - 両因子の非零条件の下で積の valuation を加法化する。
+- `padicValNat.eq_zero_of_not_dvd`
+  - `¬ q ∣ a` から `padicValNat q a = 0`
+- `Nat.add_sub_cancel_right`
+  - GN power lift の加法式を差冪 factorization に戻す。
+
+調査した既存の近接 API:
+
+- `DkMath.NumberTheory.GcdNext.padicValNat_factorization`
+- `DkMath.NumberTheory.Gcd.padicValNat_sub_pow_eq_padicValNat_GN_of_not_dvd_gap`
+- `DkMath.NumberTheory.PrimitiveBeam.primitive_prime_not_dvd_boundary`
+- `DkMath.NumberTheory.PrimitiveBeam.primitive_prime_padic_eq_GN`
+- `DkMath.NumberTheory.ValuationFlow.primitivePrimeFlow_boundaryMass_eq_zero`
+
+既存 `GcdNext.padicValNat_factorization` は一般の `a ^ d - b ^ d` 座標で
+同じ積公式を提供する。今回の ABC wrapper では checkpoint 001 の
+`gnPowerLift_sum` が直接 factorization を与えるため、より薄く
+`padicValNat.mul` を再利用した。
+
+## 2. 追加・変更した module
+
+追加:
+
+```text
+DkMath/ABC/GNValuationSplit.lean
+```
+
+既存 module と共有 aggregator は変更していない。公開面は直接、
+
+```lean
+import DkMath.ABC.GNValuationSplit
+```
+
+で利用する。
+
+## 3. 新規 theorem surface
+
+```text
+DkMath.ABC.Triple.powerDiff_eq_boundary_mul_GN
+DkMath.ABC.Triple.padic_powerDiff_eq_boundary_add_GN
+DkMath.ABC.Triple.padic_gnPowerLift_a_eq_boundary_add_GN
+DkMath.ABC.Triple.padic_powerDiff_eq_GN_of_not_dvd_boundary
+```
+
+## 4. 各 theorem の正確な仮定
+
+### `Triple.powerDiff_eq_boundary_mul_GN`
+
+```lean
+(T : Triple) (n : ℕ)
+```
+
+結論:
+
+```lean
+T.c ^ n - T.b ^ n = T.a * GN n T.a T.b
+```
+
+指数下界・positivity・prime 条件は不要で、`n = 0` も含む。
+
+### `Triple.padic_powerDiff_eq_boundary_add_GN`
+
+```lean
+(T : Triple) {n q : ℕ}
+(hn : 2 ≤ n)
+(ha : 0 < T.a)
+(hb : 0 < T.b)
+(hq : Nat.Prime q)
+```
+
+結論:
+
+```lean
+padicValNat q (T.c ^ n - T.b ^ n) =
+  padicValNat q T.a + padicValNat q (GN n T.a T.b)
+```
+
+### `Triple.padic_gnPowerLift_a_eq_boundary_add_GN`
+
+仮定は full split と同じ。結論は lifted triple の左座標へ直接作用する。
+
+```lean
+padicValNat q (T.gnPowerLift n).a =
+  padicValNat q T.a + padicValNat q (GN n T.a T.b)
+```
+
+### `Triple.padic_powerDiff_eq_GN_of_not_dvd_boundary`
+
+full split の仮定に加えて、
+
+```lean
+(hq_boundary : ¬ q ∣ T.a)
+```
+
+を要求し、結論は次となる。
+
+```lean
+padicValNat q (T.c ^ n - T.b ^ n) =
+  padicValNat q (GN n T.a T.b)
+```
+
+## 5. 非零条件の構成
+
+`padicValNat.mul` に必要な左因子の非零条件は、
+
+```lean
+Nat.ne_of_gt ha : T.a ≠ 0
+```
+
+で得た。
+
+右因子は既存 theorem をそのまま使った。
+
+```lean
+GN_ne_zero_nat_of_two_le hn ha hb :
+  GN n T.a T.b ≠ 0
+```
+
+素数条件は、
+
+```lean
+haveI : Fact q.Prime := ⟨hq⟩
+```
+
+として Mathlib の積公式へ渡した。
+
+## 6. primitive wrapper
+
+実装しなかった。
+
+既存の
+
+```lean
+PrimitivePrimeFactorOfDiffPow q a b d
+primitive_prime_not_dvd_boundary
+primitive_prime_padic_eq_GN
+```
+
+は、`a := T.c`, `b := T.b` と置けば ABC boundary
+`T.c - T.b = T.a` へ接続できる。しかし、その wrapper のためだけに
+`PrimitiveBeam` と Zsigmondy research 層を ABC の最小 valuation module
+へ import すると依存が大きくなる。checkpoint 002 の一般
+`¬ q ∣ T.a` specialization は primitive prime より広く、必要な差し替え口を
+既に提供するため、primitive 接続は後続 checkpoint 側へ残した。
+
+## 7. 数学的に閉じたこと
+
+ABC triple の差冪を、
+
+```text
+boundary contribution  v_q(T.a)
+kernel contribution    v_q(GN n T.a T.b)
+```
+
+へ正確に分離した。さらに boundary を割らない prime では boundary
+contribution が 0 となり、差冪の valuation 全体が GN kernel 上に移る。
+
+この checkpoint は exceptional prime、valuation excess、ABC quality の
+いずれも定義・主張していない。
+
+## 8. ローカル build
+
+実行:
+
+```text
+lake build DkMath.ABC.GNValuationSplit
+```
+
+結果:
+
+```text
+Build completed successfully (8263 jobs).
+```
+
+`git diff --check` は成功した。新 module に `axiom`, `sorry`,
+`native_decide` はない。
+
+instruction-002 に従い、commit、push、PR 操作、GitHub CI は行っていない。
+
+## 9. FLT7 / 共有領域
+
+`DkMath/FLT/Seven/**`、FLT7 専用 docs、FLT module、共有 aggregator は
+参照・変更していない。変更は新規 ABC module と本 report のみである。
+
+## 10. 次 checkpoint 候補
+
+次 checkpoint へは自動で進まない。賢狼レビュー後の最小候補は、
+この split を入力として `q ∣ n` / `q ∤ n` を分離し、指数由来の
+exceptional layer と non-exceptional GN valuation を theorem surface 上で
+区別することである。

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-003.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-003.md
@@ -1,0 +1,53 @@
+# Report 003: exponent-exception / non-exceptional GN layer
+
+## Outcome
+
+`ABC-GN-004` is complete (Outcome A).
+
+The new module is:
+
+```text
+DkMath/ABC/GNExceptionalSplit.lean
+```
+
+It reuses:
+
+```text
+DkMath.NumberTheory.Gcd.gcd_gap_GN_dvd_exp
+Triple.padic_powerDiff_eq_GN_of_not_dvd_boundary
+```
+
+and exports:
+
+```text
+Triple.gcd_boundary_GN_dvd_exp
+Triple.dvd_exp_of_dvd_boundary_of_dvd_GN
+Triple.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+Triple.padic_powerDiff_eq_GN_of_not_dvd_exp_of_dvd_GN
+Triple.coprime_boundary_GN_of_coprime_exp
+```
+
+The gcd spine assumes `1 ≤ n` and `0 < T.a`.  The ABC equation gives
+`T.b < T.c`, while coprimality of `T.c` and `T.b` follows from `T.hsum` and
+`T.hcop`.  A common divisor of `T.a` and `GN n T.a T.b` therefore divides
+`n`.  Contraposition gives boundary separation when `q ∤ n`.
+
+The valuation concentration theorem assumes `2 ≤ n`, positive `T.a,T.b`,
+`Nat.Prime q`, `q ∤ n`, and `q ∣ GN n T.a T.b`.  Separation supplies
+`q ∤ T.a`, after which the checkpoint-002 valuation theorem applies.
+
+`UniqueFactorizationGN` was not imported.  The thinner `Gcd.GN` API was
+sufficient.  No aggregator was changed.
+
+## Verification
+
+```text
+lake build DkMath.ABC.GNExceptionalSplit
+Build completed successfully (8279 jobs).
+```
+
+No new `axiom`, `sorry`, or `native_decide` was added.  No FLT7 module or
+shared aggregator was changed.
+
+By later explicit User authorization, work continued beyond this checkpoint.
+

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-004.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-004.md
@@ -1,0 +1,99 @@
+# Report 004: valuation excess and current proof frontier
+
+## Completed theorem surfaces
+
+`ABC-GN-005` is complete in:
+
+```text
+DkMath/ABC/GNValuationExcess.lean
+```
+
+The module defines finite logarithmic multiplicity excess and its GN,
+exceptional, and non-exceptional specializations.  For nonzero `m` it proves
+the exact identity
+
+```text
+log m = log (rad m) + valuationExcess m
+```
+
+and partitions GN excess exactly into the `q ∣ n` and `q ∤ n` sums.
+
+The local part of `ABC-GN-007` is packaged in:
+
+```text
+DkMath/ABC/GNHighLift.lean
+```
+
+It defines square high-lift primes, splits them into exponent-exceptional and
+non-exceptional layers, proves the layers disjoint, and connects `q^2 ∣ GN`
+with `2 ≤ padicValNat q GN`.  Absence of a square lift bounds the local GN
+valuation by one; on a non-exceptional channel the same bound transfers to
+the full power difference.
+
+## ABC-GN-006 deterministic bridge
+
+The proved portion is in:
+
+```text
+DkMath/ABC/GNQualityExcessBridge.lean
+```
+
+For positive ABC-radical logarithm, `Q < quality T` yields the exact strict
+height inequality
+
+```text
+Q * log (rad (a*b*c)) < log c.
+```
+
+Two named obligations expose the remaining transport:
+
+```text
+GNReturnLowerBound
+GNSupportBudget
+```
+
+Given these estimates, high quality forces the quantitative lower bound
+
+```text
+(κ * (1 + ε) - σ) * log (rad (a*b*c))
+  < GNValuationExcess n a b.
+```
+
+This is not advertised as an unconditional completion of `ABC-GN-006`.
+Proving the return and support estimates uniformly is precisely the missing
+global mathematics.
+
+## Honest roadmap frontier
+
+```text
+ABC-GN-004  complete
+ABC-GN-005  complete
+ABC-GN-006  deterministic reduction complete; two global estimates open
+ABC-GN-007  local obstruction API complete; global rarity/bound open
+ABC-GN-008  blocked on a uniform bound for exceptional/nonexceptional excess
+ABC-GN-009  blocked on 008
+ABC-GN-010  audit result: abc_main still calls abc_main_axiom directly
+```
+
+In particular, finite exceptional absorption and a valid `K_ε` cannot be
+constructed from the current source merely by finite-sum bookkeeping.  The
+existing `ABCMainTheorem.K_eps` is explicitly a placeholder, and
+`abc_main` remains exactly an application of `abc_main_axiom`.
+
+## Verification
+
+```text
+lake build DkMath.ABC.GNHighLift
+Build completed successfully (8321 jobs).
+
+lake build DkMath.ABC.GNQualityExcessBridge
+Build completed successfully (8325 jobs).
+```
+
+No new `axiom`, `sorry`, or `native_decide` was added.  Existing upstream
+warnings, including the pre-existing research `sorry`, were replayed by the
+import graph but were not introduced or used as a claimed closure here.
+`#print axioms` on the six representative new endpoints reports only
+`propext`, `Classical.choice`, and `Quot.sound`; it does not report the
+pre-existing research declaration or `abc_main_axiom`.
+No commit, push, PR, or CI operation was performed.

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-005.md
@@ -1,0 +1,126 @@
+# Report 005: unconditional GN return and high-lift carriers
+
+## Outcome
+
+Outcome A is complete:
+
+```text
+unconditional GN return: closed
+quality-to-excess: reduced to support budget only
+valuation excess: exact finite high-lift carrier sum
+```
+
+## Natural and logarithmic GN return
+
+`DkMath/ABC/GNPowerLift.lean` adds:
+
+```text
+Triple.pow_pred_c_le_GN
+```
+
+Under `1 ≤ n` and `0 < T.a`, it proves
+`T.c^(n-1) ≤ GN n T.a T.b`.  The proof uses Route 2.  From `T.b ≤ T.c` it
+gets `T.b^n ≤ T.b * T.c^(n-1)`, combines this with
+`T.a * GN + T.b^n = T.c^n`, rewrites `T.c = T.a + T.b`, and cancels the
+positive factor `T.a`.  No natural-number division is used.
+
+`DkMath/ABC/GNQualityExcessBridge.lean` adds:
+
+```text
+Triple.log_c_mul_pred_le_log_GN
+Triple.gnReturnLowerBound_pred
+```
+
+Thus `GNReturnLowerBound T n (n-1)` is fully discharged for `2 ≤ n` and
+positive coordinates.
+
+## Radical-log positivity
+
+The same module adds:
+
+```text
+Triple.log_rad_abc_pos
+```
+
+Positive `T.a,T.b` imply `2 ≤ T.a*T.b*T.c`; the existing
+`log_rad_pos_of_two_le` then closes strict positivity.  Reduced public quality
+bridges no longer request an explicit radical-log positivity hypothesis.
+
+## Pure and affine support budgets
+
+The following surfaces are available:
+
+```text
+GNSupportBudget
+GNSupportBudgetAffine
+GNSupportBudget.toAffine
+Triple.GNValuationExcess_gt_of_quality_gt_affine
+Triple.GNValuationExcess_gt_of_quality_gt_pred_affine
+Triple.GNValuationExcess_gt_of_quality_gt_pred
+```
+
+The affine conclusion is:
+
+```text
+(((n-1)*(1+ε)-σ) * log(rad(a*b*c))) - C
+  < GNValuationExcess n a b.
+```
+
+The `pred` versions internally use the unconditional return coefficient
+`n-1`.  Their only global transport input is respectively an affine or pure
+GN support budget.
+
+No uniform support-budget theorem is asserted.  At this frontier:
+
+```text
+n may be fixed or varying;
+σ may depend on n;
+C may depend on n and ε;
+the supplied budget is pointwise in T;
+no theorem uniform over all positive ABC triples has been proved.
+```
+
+A useful budget must retain a positive net margin
+`(n-1)*(1+ε)-σ`; existence of an arbitrary pointwise `σ` is insufficient.
+
+## Exact high-lift carriers
+
+`DkMath/ABC/GNHighLift.lean` adds:
+
+```text
+highLiftSupport
+valuationExcess_eq_sum_highLift
+GNValuationExcess_eq_sum_highLift
+GNValuationExcess_eq_zero_of_no_highLift
+```
+
+The carrier is the factorization support filtered by `q^2 ∣ m`.  A support
+prime outside this filter has factorization exponent exactly one, hence its
+excess summand is zero.  Therefore the restriction is an exact equality, not
+an estimate.  In particular, absence of GN prime-square carriers forces zero
+GN valuation excess.
+
+## Validation
+
+```text
+lake build DkMath.ABC.GNPowerLift
+Build completed successfully (8262 jobs).
+
+lake build DkMath.ABC.GNQualityExcessBridge
+Build completed successfully (8338 jobs).
+
+lake build DkMath.ABC.GNHighLift
+Build completed successfully (8321 jobs).
+```
+
+No new `axiom`, `sorry`, or `native_decide` was added.  FLT7 modules and
+shared aggregators were untouched.  No commit, push, PR, or CI action was
+performed.  `#print axioms` on six representative new endpoints reports only
+`propext`, `Classical.choice`, and `Quot.sound`.
+
+## Next mathematical obligation
+
+The single next obligation is a quantitatively useful affine
+`GNSupportBudget`: with exact dependencies on fixed/varying `n`, `σ`, and
+`C`, and with a positive net margin.  This checkpoint does not begin that
+proof.

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-006.md
@@ -1,0 +1,152 @@
+# Report 006: finite exceptional absorption and lifted-radical return
+
+## Outcome
+
+Outcome A is complete in:
+
+```text
+DkMath/ABC/GNSupportReturn.lean
+```
+
+## Exact support definitions and partition
+
+The module defines:
+
+```text
+GNExceptionalSupport
+GNNonExceptionalSupport
+GNExceptionalSupportProduct
+GNNonExceptionalSupportProduct
+```
+
+and proves:
+
+```text
+GN_support_eq_exceptional_union_nonExceptional
+GNExceptionalSupport_disjoint_nonExceptional
+rad_GN_eq_exceptional_mul_nonExceptional
+```
+
+Thus GN factorization support is an exact disjoint filtered partition, and
+its radical is exactly the product of the two squarefree support products.
+
+## Exceptional absorption
+
+```text
+GNExceptionalSupportProduct_dvd_rad
+log_GNExceptionalSupportProduct_le_log_rad
+log_rad_GN_le_log_rad_exp_add_log_nonExceptional
+```
+
+Every exceptional member is a prime factorization-support member satisfying
+`q ∣ n`.  The existing
+`prime_channel_family_prod_dvd_supportMass` theorem sends their finite product
+into `supportMass n`, and `supportMass_eq_abc_rad` identifies this with
+`rad n`.  Consequently:
+
+```text
+log(rad GN) ≤ log(rad n) + log(nonExceptionalProduct).
+```
+
+## Freshness
+
+```text
+Triple.nonExceptionalSupport_fresh
+```
+
+For `1 ≤ n`, `0 < T.a`, and `q` in non-exceptional GN support, it proves:
+
+```text
+Prime q
+q ∣ GN
+q ∤ T.a
+q ∤ T.b
+q ∤ T.c
+q ∤ T.a*T.b*T.c
+```
+
+Boundary freshness uses the exponent-exception theorem.  Freshness from
+`T.b` and `T.c` uses coprimality of the GN power lift: `q ∣ GN` places `q`
+in the lifted left coordinate, while divisibility of `b` or `c` would place
+it in the corresponding powered coordinate.
+
+## Lifted radical bridge
+
+```text
+Triple.rad_mul_nonExceptionalProduct_dvd_lift_rad
+Triple.log_rad_add_log_nonExceptional_le_log_lift_rad
+```
+
+For `2 ≤ n` and positive `T.a,T.b`:
+
+```text
+rad(a*b*c) * nonExceptionalProduct
+  ∣ rad(lift.a * lift.b * lift.c).
+```
+
+The proof forms the disjoint union of original ABC prime support and fresh
+non-exceptional GN support.  Every union member is a prime channel of the
+lifted coordinate product, so the finite prime-family support-mass theorem
+gives the divisibility.  No false `rad(GN) ≤ rad(abc)` transport is used.
+
+## Exact affine transport
+
+The module defines:
+
+```text
+GNLiftRadicalGrowthBudgetAffine
+GNNonExceptionalSupportBudgetAffine
+```
+
+and proves the deterministic chain:
+
+```text
+Triple.nonExceptionalSupportBudgetAffine_of_liftGrowth
+Triple.GNSupportBudgetAffine_of_nonExceptional
+Triple.GNSupportBudgetAffine_of_liftGrowth
+```
+
+The constants transport exactly as:
+
+```text
+lift growth budget (σ,C)
+  -> non-exceptional budget (σ,C)
+  -> full GN support budget (σ, C + log(rad n)).
+```
+
+Finally:
+
+```text
+Triple.GNValuationExcess_gt_of_quality_gt_liftGrowth
+```
+
+proves the excess lower bound
+
+```text
+(((n-1)*(1+ε)-σ) * log(rad(a*b*c)))
+  - (C + log(rad n))
+  < GNValuationExcess n a b
+```
+
+from high quality and the lifted-radical-growth budget alone.
+
+## Remaining global obligation
+
+The remaining input is a quantitatively useful, genuinely uniform
+`GNLiftRadicalGrowthBudgetAffine` (or equivalently a non-exceptional support
+growth bound) with a positive net margin.  No such uniform theorem, high-lift
+rarity result, `K_ε`, or ABC conclusion is claimed here.
+
+## Validation and scope
+
+```text
+lake build DkMath.ABC.GNSupportReturn
+Build completed successfully (8342 jobs).
+```
+
+No new `axiom`, `sorry`, or `native_decide` was added.  The direct import
+`DkMath.ABC.GNSupportReturn` is sufficient; no shared aggregator was changed.
+`#print axioms` on six representative endpoints reports only `propext`,
+`Classical.choice`, and `Quot.sound`.
+FLT7 modules and documentation were untouched.  No commit, push, PR, or CI
+operation was performed.

--- a/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-007.md
+++ b/lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/report-007.md
@@ -1,0 +1,195 @@
+# Report 007: 二予算による ABC 最終合成
+
+## 結果
+
+Outcome A を達成した。新規 module は次である。
+
+```text
+DkMath/ABC/GNFinalBudgetBridge.lean
+```
+
+この checkpoint では、
+
+```text
+prime-support growth budget
++
+valuation-multiplicity budget
+  -> explicit K を持つ ABC bound
+```
+
+という最終合成を Lean theorem surface として固定した。
+
+## valuation-excess budget
+
+次の三つの affine budget predicate を定義した。
+
+```text
+GNValuationExcessBudgetAffine
+GNExceptionalExcessBudgetAffine
+GNNonExceptionalExcessBudgetAffine
+```
+
+いずれも ABC radical の対数に対する線形係数と加法定数を持つ。
+
+既存の exact partition
+
+```text
+GNValuationExcess
+  = GNExceptionalValuationExcess
+  + GNNonExceptionalValuationExcess
+```
+
+から、次を証明した。
+
+```text
+GNValuationExcessBudgetAffine.of_split
+```
+
+exceptional budget `(τe, De)` と non-exceptional budget `(τn, Dn)` は、
+full budget `(τe + τn, De + Dn)` に合成される。
+
+有限個の exceptional prime support と、その prime 上の valuation depth
+は区別している。`exceptional support product ∣ rad n` だけから
+exceptional valuation multiplicity の一様上界は主張していない。
+
+## support / excess の合流
+
+次を証明した。
+
+```text
+Triple.log_c_mul_pred_le_of_support_and_excessBudget
+```
+
+証明経路は正確に、
+
+```text
+(n-1) log c ≤ log GN
+log GN = log(rad GN) + GNValuationExcess
+log(rad GN) ≤ σ log R + Cs
+GNValuationExcess ≤ τ log R + Ce
+```
+
+であり、結論は
+
+```text
+(n-1) log c ≤ (σ+τ) log R + (Cs+Ce)
+```
+
+である。
+
+lifted-radical growth specialization は、
+
+```text
+Triple.log_c_mul_pred_le_of_liftGrowth_and_excessBudget
+```
+
+であり、exceptional support の有限費用を消さず、
+
+```text
+(n-1) log c
+  ≤ (σ+τ) log R + Cs + Ce + log(rad n)
+```
+
+を得る。
+
+## 明示定数と pointwise ABC theorem
+
+実装した定数は次である。
+
+```lean
+GNABCConstant n Cs Ce =
+  max 1 (Real.exp |Cs + Ce + Real.log (rad n : ℝ)|)
+```
+
+instruction の除算型定数と同じく `T` に依存せず、依存するのは
+`n`, `Cs`, `Ce` のみである。絶対値を使うことで affine constant の
+符号分岐を避けた、やや粗いが明示的な定数である。
+
+```text
+one_le_GNABCConstant
+Triple.abc_bound_of_liftGrowth_and_excessBudget
+```
+
+margin
+
+```text
+σ + τ ≤ (n-1) * (1+ε)
+```
+
+のもとで、
+
+```text
+c ≤ GNABCConstant n Cs Ce * rad(a*b*c)^(1+ε)
+```
+
+を証明した。証明は対数不等式を正の `(n-1)` で正規化し、
+`Real.exp_le_exp`, `Real.exp_log`, `Real.exp_add`,
+`Real.rpow_def_of_pos` で実数冪へ戻している。
+
+## global final contract
+
+次の structure を追加した。
+
+```text
+ABCGNFinalBudgetContract
+```
+
+内容は、
+
+```text
+fixed n ≥ 2
+uniform lifted-radical support-growth budget
+uniform exceptional valuation-excess budget
+uniform non-exceptional valuation-excess budget
+positive margin
+```
+
+である。
+
+これから、
+
+```text
+abc_positive_of_GNFinalBudgetContract
+```
+
+を証明した。結論は正の ABC triple 全体に一つの `K ≥ 1` が使える
+global ABC theorem である。
+
+`a=0` / `b=0` endpoint を現行 `abc_main_axiom` と同じ生引数 surface
+へ接続する拡張は行っていない。今回証明した契約と theorem の範囲は
+明示的に positive triple である。`abc_main_axiom` は変更も利用もして
+いない。
+
+## 残る数学
+
+Lean で証明済み：
+
+```text
+support budget + valuation-excess budget
+  -> explicit K_epsilon ABC bound
+```
+
+未証明：
+
+```text
+uniform lifted-radical support growth
+uniform exceptional valuation excess
+uniform non-exceptional valuation excess
+```
+
+したがって、これは ABC 予想そのものの証明ではない。ただし
+`abc_main_axiom` の positive-triple 内容を置換するために必要な一様契約は、
+上記三予算へ正確に還元された。
+
+## ローカル検証と変更範囲
+
+```text
+lake build DkMath.ABC.GNFinalBudgetBridge
+Build completed successfully (8343 jobs).
+```
+
+新しい `axiom`, `sorry`, `native_decide` は追加していない。
+代表的な五つの新規 endpoint に対する `#print axioms` は、
+`propext`, `Classical.choice`, `Quot.sound` のみを報告した。
+共有 aggregator、FLT7 module、FLT7 documentation は変更していない。
+commit、push、PR、CI 操作は行っていない。


### PR DESCRIPTION
## Summary

This PR integrates the completed ABC–GN deterministic workbench from:

```text
wip/ABC-GN-valuation-excess-260724-Codex
```

into:

```text
feature/ABC-GN-valuation-excess-260724-v0
```

The implementation reconnects the existing general `GN`, `padicValNat`, factorization, radical/support, primitive-prime, and valuation APIs into a single deterministic ABC route.

## Final integrated route

```text
ABC triple
  -> GN power lift
  -> boundary / GN p-adic split
  -> q | n / q ∤ n exceptional split
  -> exact radical-support / valuation-multiplicity identity
  -> unconditional GN return
  -> exceptional support absorption into rad n
  -> fresh non-exceptional support return through the lifted triple
  -> support-growth budget + valuation-excess budget
  -> explicit K-epsilon ABC bound
```

Completed checkpoints:

```text
ABC-GN-001  GN power lift
ABC-GN-002  coprime / support separation
ABC-GN-003  p-adic boundary–GN split
ABC-GN-004  exponent-exceptional / non-exceptional split
ABC-GN-005  exact log(rad) + valuation-excess identity
ABC-GN-006  unconditional GN return and quality bridge
ABC-GN-007  finite high-lift carrier API
ABC-GN-008  exceptional support absorption and fresh radical return
ABC-GN-009  two-budget composition and explicit K-epsilon bridge
```

## Main Lean endpoint

`ABCGNFinalBudgetContract` packages three uniform hypotheses:

```text
1. uniform lifted-radical support growth
2. uniform exceptional valuation excess
3. uniform non-exceptional valuation excess
```

Together with the positive margin condition, the theorem

```lean
abc_positive_of_GNFinalBudgetContract
```

produces one explicit `K >= 1` valid for every positive ABC triple:

```text
c <= K * rad(a*b*c)^(1+epsilon)
```

The pointwise bridge is exposed by:

```lean
Triple.abc_bound_of_liftGrowth_and_excessBudget
```

## Mathematical status

This PR does **not** prove the ABC conjecture and does not remove `abc_main_axiom`.

It completes the deterministic translation and composition layer and isolates the remaining mathematical content as three explicit uniform budget problems. A stronger support–multiplicity balance theorem may eventually replace separate proofs of all three.

The remaining research cores are intentionally left for a later branch or checkpoint:

```text
uniform lifted-radical support growth
uniform exceptional valuation excess
uniform non-exceptional valuation excess
```

## Validation

```text
lake build DkMath.ABC.GNFinalBudgetBridge
Build completed successfully (8343 jobs)

GitHub Lean CI run 271
conclusion: success
```

Axiom audit for the main new endpoints reports only:

```text
propext
Classical.choice
Quot.sound
```

No new `axiom`, `sorry`, or `native_decide` proof was introduced. `abc_main_axiom` was neither modified nor used as a proof input.

## Documentation

The implementation history, theorem map, trust boundary, remaining mathematical cores, and restart plan are recorded in:

```text
lean/dk_math/docs/dev/ABC-GN-valuation-excess-260724-v0/FINAL_REPORT.md
```

`CODEX_START.md` is intentionally paused. There is no active implementation instruction after this integration checkpoint.

## Scope boundaries

- no FLT7 source or documentation changes;
- no shared aggregator expansion;
- no claim that the uniform budgets have been proved;
- no automatic continuation beyond ABC-GN-009.