### PR TITLE
ABC–GN M1: eliminate odd-prime exceptional valuation excess

### DIFF
--- a/lean/dk_math/DkMath/ABC.lean
+++ b/lean/dk_math/DkMath/ABC.lean
@@ -5,6 +5,7 @@ Authors: D. and Wise Wolf.
 -/
 
 import DkMath.ABC.Main
+import DkMath.ABC.GNExceptionalExcessOddPrime
 
 #print "file: DkMath.ABC"
 

--- a/lean/dk_math/DkMath/ABC/GNExceptionalExcessFive.lean
+++ b/lean/dk_math/DkMath/ABC/GNExceptionalExcessFive.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+
+#print "file: DkMath.ABC.GNExceptionalExcessFive"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# Vanishing of the exceptional GN excess at exponent five
+
+This module connects the local factorization-one result at exponent five to
+the exceptional filtered sum and its affine budget.  No positivity hypotheses
+on the coordinates of an ABC triple are needed.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/--
+The exponent-exceptional valuation excess vanishes identically at exponent
+five for an ABC triple.
+-/
+theorem Triple.GNExceptionalValuationExcess_five_eq_zero
+    (T : Triple) :
+    GNExceptionalValuationExcess 5 T.a T.b = 0 := by
+  classical
+  unfold GNExceptionalValuationExcess
+  apply Finset.sum_eq_zero
+  intro q hq
+  obtain ⟨hqSupport, hqDvdFive⟩ := Finset.mem_filter.mp hq
+  have hqPrime : q.Prime := by
+    rw [Nat.support_factorization] at hqSupport
+    exact Nat.prime_of_mem_primeFactors hqSupport
+  have hqEq : q = 5 :=
+    (Nat.prime_dvd_prime_iff_eq hqPrime Nat.prime_five).mp hqDvdFive
+  subst q
+  have h5GN : 5 ∣ GN 5 T.a T.b :=
+    Nat.dvd_of_factorization_pos (Finsupp.mem_support_iff.mp hqSupport)
+  rw [factorization_five_GN_five_eq_one_of_dvd T.hcop h5GN]
+  simp
+
+/--
+At exponent five, the exceptional affine excess budget is exactly zero.
+-/
+theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
+    (T : Triple) :
+    GNExceptionalExcessBudgetAffine T 5 0 0 := by
+  unfold GNExceptionalExcessBudgetAffine
+  rw [T.GNExceptionalValuationExcess_five_eq_zero]
+  simp
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNExceptionalExcessOddPrime.lean
+++ b/lean/dk_math/DkMath/ABC/GNExceptionalExcessOddPrime.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+
+#print "file: DkMath.ABC.GNExceptionalExcessOddPrime"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# Vanishing of exceptional GN excess at odd-prime exponents
+
+For an odd prime exponent, the only possible exponent-exceptional support
+prime is the exponent itself.  Its GN multiplicity is exactly one, so the
+entire exceptional valuation excess and its affine budget vanish.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/--
+The exponent-exceptional valuation excess vanishes at every odd-prime
+exponent.
+-/
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalValuationExcess p T.a T.b = 0 := by
+  classical
+  unfold GNExceptionalValuationExcess
+  apply Finset.sum_eq_zero
+  intro q hq
+  obtain ⟨hqSupport, hqDvdP⟩ := Finset.mem_filter.mp hq
+  have hqPrime : q.Prime := by
+    rw [Nat.support_factorization] at hqSupport
+    exact Nat.prime_of_mem_primeFactors hqSupport
+  have hqEq : q = p :=
+    (Nat.prime_dvd_prime_iff_eq hqPrime hp).mp hqDvdP
+  subst q
+  have hpGN : p ∣ GN p T.a T.b :=
+    Nat.dvd_of_factorization_pos (Finsupp.mem_support_iff.mp hqSupport)
+  rw [factorization_GN_prime_eq_one_of_dvd hp hpOdd T.hcop hpGN]
+  simp
+
+/-- The exceptional affine excess budget is exactly zero at odd-prime exponents. -/
+theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalExcessBudgetAffine T p 0 0 := by
+  unfold GNExceptionalExcessBudgetAffine
+  rw [T.GNExceptionalValuationExcess_eq_zero_of_oddPrime hp hpOdd]
+  simp
+
+/--
+At an odd-prime exponent, a non-exceptional affine budget is already a budget
+for the full GN valuation excess.
+-/
+theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
+    (T : Triple) {p : ℕ} {τn Dn : ℝ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
+    GNValuationExcessBudgetAffine T p τn Dn := by
+  have he : GNExceptionalExcessBudgetAffine T p 0 0 :=
+    T.GNExceptionalExcessBudgetAffine_zero_of_oddPrime hp hpOdd
+  simpa using GNValuationExcessBudgetAffine.of_split he hn
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+++ b/lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 D. and Wise Wolf. All rights reserved.
+Released under MIT license as described in the file LICENSE.
+Authors: D. and Wise Wolf.
+-/
+
+import DkMath.ABC.GNValuationExcess
+
+#print "file: DkMath.ABC.GNOddPrimeExceptionalExcess"
+
+set_option linter.style.longLine false
+set_option linter.style.emptyLine false
+
+/-!
+# The exceptional GN valuation at exponent five
+
+This module proves the local arithmetic kernel for the prime dividing the
+exponent when that exponent is five.  For coprime boundary coordinates, a
+factor of five in `GN 5 a b` occurs with valuation exactly one.
+
+The finite exceptional-support sum and the general odd-prime case are outside
+the scope of this module.
+-/
+
+namespace DkMath.ABC
+
+open DkMath.CosmicFormulaBinom
+
+/-- The canonical general `GN` polynomial specialized to exponent five. -/
+theorem GN_five_eq_explicit (a b : ℕ) :
+    GN 5 a b =
+      a ^ 4 + 5 * a ^ 3 * b + 10 * a ^ 2 * b ^ 2 +
+        10 * a * b ^ 3 + 5 * b ^ 4 := by
+  rw [GN_eq_sum]
+  norm_num [Finset.sum_range_succ, Nat.choose]
+  ring
+
+/-- At exponent five, every non-boundary term has a visible factor of five. -/
+theorem GN_five_eq_boundary_add_five_mul (a b : ℕ) :
+    GN 5 a b =
+      a ^ 4 +
+        5 * (a ^ 3 * b + 2 * a ^ 2 * b ^ 2 + 2 * a * b ^ 3 + b ^ 4) := by
+  rw [GN_five_eq_explicit]
+  ring
+
+/--
+If the exponent-five GN kernel is divisible by five, then its boundary
+coordinate is divisible by five.
+-/
+theorem five_dvd_boundary_of_dvd_GN_five
+    {a b : ℕ} (h5GN : 5 ∣ GN 5 a b) :
+    5 ∣ a := by
+  have hGNmod : GN 5 a b % 5 = 0 :=
+    Nat.mod_eq_zero_of_dvd h5GN
+  have haPowMod : a ^ 4 % 5 = 0 := by
+    rw [GN_five_eq_boundary_add_five_mul] at hGNmod
+    simpa [Nat.add_mod] using hGNmod
+  have haPow : 5 ∣ a ^ 4 :=
+    Nat.dvd_iff_mod_eq_zero.mpr haPowMod
+  exact Nat.prime_five.dvd_of_dvd_pow haPow
+
+/--
+After substituting a factor of five in the boundary coordinate, all terms
+except `5 * b^4` have a visible factor of twenty-five.
+-/
+theorem GN_five_five_mul_eq_twentyFive_mul_add (k b : ℕ) :
+    GN 5 (5 * k) b =
+      25 * (25 * k ^ 4 + 25 * k ^ 3 * b + 10 * k ^ 2 * b ^ 2 +
+        2 * k * b ^ 3) + 5 * b ^ 4 := by
+  rw [GN_five_eq_explicit]
+  ring
+
+/--
+For coprime boundary coordinates, divisibility by five cannot lift to
+divisibility by twenty-five.
+-/
+theorem not_twentyFive_dvd_GN_five_of_coprime
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    ¬ 25 ∣ GN 5 a b := by
+  intro h25GN
+  obtain ⟨k, rfl⟩ := five_dvd_boundary_of_dvd_GN_five h5GN
+  let K :=
+    25 * k ^ 4 + 25 * k ^ 3 * b + 10 * k ^ 2 * b ^ 2 +
+      2 * k * b ^ 3
+  have hdecomp : GN 5 (5 * k) b = 25 * K + 5 * b ^ 4 := by
+    simpa [K] using GN_five_five_mul_eq_twentyFive_mul_add k b
+  obtain ⟨t, ht⟩ := h25GN
+  have hbPow : 5 ∣ b ^ 4 := by
+    refine ⟨t - K, ?_⟩
+    omega
+  have h5b : 5 ∣ b :=
+    Nat.prime_five.dvd_of_dvd_pow hbPow
+  have h5copb : Nat.Coprime 5 b :=
+    hcop.coprime_dvd_left (by exact dvd_mul_right 5 k)
+  exact (Nat.prime_five.coprime_iff_not_dvd.mp h5copb) h5b
+
+/--
+For coprime boundary coordinates, a factor of five in the exponent-five GN
+kernel has exact p-adic valuation one.
+-/
+theorem padicValNat_five_GN_five_eq_one_of_dvd
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    padicValNat 5 (GN 5 a b) = 1 := by
+  have hNoSquare :=
+    not_twentyFive_dvd_GN_five_of_coprime hcop h5GN
+  have hGN0 : GN 5 a b ≠ 0 := by
+    intro hzero
+    apply hNoSquare
+    rw [hzero]
+    exact dvd_zero 25
+  have hOneLe : 1 ≤ padicValNat 5 (GN 5 a b) :=
+    padicValNat_one_le_of_prime_dvd Nat.prime_five hGN0 h5GN
+  have hLtTwo : padicValNat 5 (GN 5 a b) < 2 := by
+    by_contra hNot
+    have hTwoLe : 2 ≤ padicValNat 5 (GN 5 a b) :=
+      Nat.le_of_not_gt hNot
+    apply hNoSquare
+    have hPowDvd :=
+      (padicValNat_le_iff_dvd Nat.prime_five hGN0 2).mp hTwoLe
+    norm_num at hPowDvd ⊢
+    exact hPowDvd
+  omega
+
+/-- Factorization form of the exact exponent-five exceptional valuation. -/
+theorem factorization_five_GN_five_eq_one_of_dvd
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    (GN 5 a b).factorization 5 = 1 := by
+  rw [Nat.factorization_def (GN 5 a b) Nat.prime_five]
+  exact padicValNat_five_GN_five_eq_one_of_dvd hcop h5GN
+
+end DkMath.ABC

--- a/lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+++ b/lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
@@ -5,6 +5,7 @@ Authors: D. and Wise Wolf.
 -/
 
 import DkMath.ABC.GNValuationExcess
+import DkMath.NumberTheory.WeightedGNBridge
 
 #print "file: DkMath.ABC.GNOddPrimeExceptionalExcess"
 
@@ -12,19 +13,131 @@ set_option linter.style.longLine false
 set_option linter.style.emptyLine false
 
 /-!
-# The exceptional GN valuation at exponent five
+# The exceptional GN valuation at odd-prime exponents
 
-This module proves the local arithmetic kernel for the prime dividing the
-exponent when that exponent is five.  For coprime boundary coordinates, a
-factor of five in `GN 5 a b` occurs with valuation exactly one.
+This module proves the local arithmetic kernel for a prime dividing a GN
+kernel whose exponent is that same odd prime.  For coprime boundary
+coordinates, such a factor occurs with valuation exactly one.
 
-The finite exceptional-support sum and the general odd-prime case are outside
-the scope of this module.
+The original explicit exponent-five specialization is retained as a concrete
+local instance.  Exceptional-support finite sums remain in separate bridge
+modules.
 -/
 
 namespace DkMath.ABC
 
 open DkMath.CosmicFormulaBinom
+
+/--
+The canonical GN kernel is the geometric quotient between `(a + b)^p` and
+`b^p`.
+-/
+theorem GN_eq_geom_sum₂ (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i) := by
+  by_cases ha : a = 0
+  · subst a
+    rw [show GN p 0 b = p * b ^ (p - 1) by
+      simpa [GN] using
+        (DkMath.CosmicFormula.GN_zero_eval (R := ℕ) p b)]
+    simpa using (geom_sum₂_self b p).symm
+  · let S :=
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i)
+    have hGN := cosmic_id_csr p a b
+    have hGeom := geom_sum₂_mul_add a b p
+    have hEq : S * a = a * GN p a b := by
+      dsimp [BigN, BodyN, GapN] at hGN
+      dsimp [S]
+      omega
+    have hMul : a * GN p a b = a * S := by
+      simpa [Nat.mul_comm] using hEq.symm
+    exact Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero ha) hMul
+
+/--
+At a prime exponent, divisibility of the GN kernel by the exponent forces
+divisibility of the boundary coordinate.
+-/
+theorem prime_dvd_boundary_of_dvd_GN_prime
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpGN : p ∣ GN p a b) :
+    p ∣ a := by
+  obtain ⟨B, hGN⟩ :=
+    DkMath.NumberTheory.prime_exists_GN_eq_mul_add_rightBoundary
+      (x := a) (u := b) hp
+  have hpPow : p ∣ a ^ (p - 1) := by
+    rw [hGN] at hpGN
+    have hpGN' : p ∣ a ^ (p - 1) + p * B := by
+      simpa [Nat.add_comm] using hpGN
+    exact (Nat.dvd_add_iff_left (dvd_mul_right p B)).mpr hpGN'
+  exact hp.dvd_of_dvd_pow hpPow
+
+/--
+For an odd prime exponent and coprime boundary coordinates, an exponent-prime
+factor in `GN` has exact p-adic valuation one.
+-/
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1 := by
+  have hpa : p ∣ a :=
+    prime_dvd_boundary_of_dvd_GN_prime hp hpGN
+  have hpb : ¬ p ∣ b := by
+    have hpcopb : Nat.Coprime p b :=
+      hcop.coprime_dvd_left hpa
+    exact hp.coprime_iff_not_dvd.mp hpcopb
+  have hpab : ¬ p ∣ a + b := by
+    intro hpab
+    apply hpb
+    have hpba : p ∣ b + a := by
+      simpa [Nat.add_comm] using hpab
+    exact (Nat.dvd_add_iff_left hpa).mpr hpba
+  have hpInt : Prime (p : ℤ) :=
+    Nat.prime_iff_prime_int.mp hp
+  have hxyInt : (p : ℤ) ∣ (a + b : ℕ) - (b : ℤ) := by
+    simpa using (Int.natCast_dvd_natCast.mpr hpa)
+  have hxInt : ¬ (p : ℤ) ∣ (a + b : ℕ) := by
+    intro hpabInt
+    apply hpab
+    exact Int.natCast_dvd_natCast.mp (by simpa using hpabInt)
+  have hEmultInt :
+      emultiplicity (p : ℤ)
+          (∑ i ∈ Finset.range p,
+            ((a + b : ℕ) : ℤ) ^ i * (b : ℤ) ^ (p - 1 - i)) = 1 :=
+    emultiplicity_geom_sum₂_eq_one hpInt hpOdd hxyInt hxInt
+  have hCast :
+      ((GN p a b : ℕ) : ℤ) =
+        ∑ i ∈ Finset.range p,
+          ((a + b : ℕ) : ℤ) ^ i * (b : ℤ) ^ (p - 1 - i) := by
+    rw [GN_eq_geom_sum₂]
+    norm_cast
+  have hEmultNat : emultiplicity p (GN p a b) = 1 := by
+    rw [← Int.natCast_emultiplicity, hCast]
+    exact hEmultInt
+  have hGN0 : GN p a b ≠ 0 := by
+    intro hzero
+    rw [hzero, emultiplicity_zero] at hEmultNat
+    exact WithTop.top_ne_one hEmultNat
+  letI : Fact p.Prime := ⟨hp⟩
+  simp only [← Nat.cast_inj (R := ℕ∞)]
+  rw [padicValNat_eq_emultiplicity hGN0, hEmultNat]
+  simp
+
+/-- Factorization form of the odd-prime exact local GN valuation. -/
+theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1 := by
+  rw [Nat.factorization_def (GN p a b) hp]
+  exact padicValNat_GN_prime_eq_one_of_dvd hp hpOdd hcop hpGN
 
 /-- The canonical general `GN` polynomial specialized to exponent five. -/
 theorem GN_five_eq_explicit (a b : ℕ) :

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-IMPLEMENTATION-DESIGN.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-IMPLEMENTATION-DESIGN.md
@@ -1,0 +1,445 @@
+# ABC–GN M1 Implementation Design
+
+副題: odd-prime exponent における exceptional valuation excess の完全消去
+
+## 1. Objective
+
+基底ブランチの `GNExceptionalValuationExcess` は、指数 `n` を割る prime channel 上の valuation multiplicity を測る。
+
+```lean
+noncomputable def GNExceptionalValuationExcess (n a b : ℕ) : ℝ :=
+  ∑ q ∈ (GN n a b).factorization.support.filter (fun q => q ∣ n),
+    (((GN n a b).factorization q - 1 : ℕ) : ℝ) * Real.log (q : ℝ)
+```
+
+M1 の目的は、`n = p` が奇素数なら、この有限和が恒等的にゼロであることを証明すること。
+
+最終 theorem shape:
+
+```lean
+/-- Odd-prime exponents carry no exponent-exceptional GN multiplicity. -/
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNExceptionalValuationExcess p T.a T.b = 0 := by
+  ...
+```
+
+Budget wrapper:
+
+```lean
+/-- The exceptional affine budget is exactly zero at odd-prime exponent. -/
+theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNExceptionalExcessBudgetAffine T p 0 0 := by
+  ...
+```
+
+`hb` は GN nonzero や既存 API との接続に必要な場合のみ残す。不要なら theorem surface から除去する。
+
+## 2. Current API facts
+
+### 2.1. Boundary–GN overlap is exponent-supported
+
+既存 theorem:
+
+```lean
+Triple.gcd_boundary_GN_dvd_exp
+Triple.dvd_exp_of_dvd_boundary_of_dvd_GN
+```
+
+意味:
+
+$$q\mid T.a\quad\land\quad q\mid GN_n(T.a,T.b)\quad\Longrightarrow\quad q\mid n$$
+
+M1 では逆方向に近い局所事実を奇素数指数で作る。
+
+$$p\mid GN_p(T.a,T.b)\quad\Longrightarrow\quad p\mid T.a$$
+
+### 2.2. Exceptional excess is a filtered finite sum
+
+既存定義では、各 summand は
+
+$$\left(v_q(GN)-1\right)\log q$$
+
+である。
+
+したがって全体をゼロにする最短 route は、filtered support の各 `q` について
+
+```lean
+(GN p T.a T.b).factorization q = 1
+```
+
+を証明すること。
+
+### 2.3. Prime support facts
+
+`q ∈ m.factorization.support` から次が得られる。
+
+```text
+q is prime
+q ∣ m
+1 ≤ m.factorization q
+```
+
+既存補題:
+
+```lean
+one_le_factorization_of_mem_support
+```
+
+Mathlib 側の support / factorization prime lemmas を reconnaissance で確認し、独自補題を増やさない。
+
+## 3. Mathematical spine
+
+`a := T.a`、`b := T.b` と書く。
+
+一般 GN は、
+
+$$GN_p(a,b)=\frac{(a+b)^p-b^p}{a}$$
+
+に対応する。
+
+奇素数 `p` に対し、目標 chain は次。
+
+### 3.1. Exceptional support collapse
+
+`q` が exceptional support に属するなら、
+
+```text
+q ∈ factorization.support (GN p a b)
+q ∣ p
+```
+
+である。
+
+support から `q` は prime、`hp : Prime p` と `q ∣ p` から、
+
+$$q=p$$
+
+を得る。
+
+候補補題:
+
+```lean
+theorem eq_exp_of_mem_exceptional_support_prime_exp
+    {p q a b : ℕ}
+    (hp : Nat.Prime p)
+    (hq : q ∈ (GN p a b).factorization.support)
+    (hqexp : q ∣ p) :
+    q = p
+```
+
+この補題は ABC triple に依存しない。
+
+### 3.2. Detection modulo p
+
+素数 `p` では中間二項係数が `p` で割れるため、
+
+$$GN_p(a,b)\equiv a^{p-1}\pmod p$$
+
+となる。
+
+したがって、
+
+$$p\mid GN_p(a,b)\Longrightarrow p\mid a^{p-1}\Longrightarrow p\mid a$$
+
+候補補題:
+
+```lean
+theorem prime_dvd_boundary_of_dvd_GN_prime_exp
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpGN : p ∣ GN p a b) :
+    p ∣ a
+```
+
+実装候補:
+
+1. general binomial coefficient congruence;
+2. an existing theorem about `gcd gap GN` specialized to prime exponent plus an additional nonzero argument;
+3. direct finite expansion only for the initial `p = 5` checkpoint.
+
+ここは reconnaissance の Outcome に応じて選ぶ。
+
+### 3.3. Coprime boundary removes p from b
+
+ABC triple では `T.hcop : Coprime T.a T.b` がある。
+
+$$p\mid a\quad\Longrightarrow\quad p\nmid b$$
+
+候補補題は新設せず、`Nat.Coprime` API を直接使う。
+
+### 3.4. Exact valuation one
+
+必要な局所定理は、
+
+$$p\mid GN_p(a,b)\Longrightarrow p^2\nmid GN_p(a,b)$$
+
+または同値な、
+
+$$v_p(GN_p(a,b))=1$$
+
+である。
+
+#### Route A: binomial modulo p²
+
+`p ∣ a`、`p ∤ b` とする。
+
+二項展開では、
+
+$$GN_p(a,b)=p b^{p-1}+\sum_{j=2}^{p-1}\binom pj a^{j-1}b^{p-j}+a^{p-1}$$
+
+中間項は `p` を係数に持ち、さらに `a` を一つ以上持つので `p²` で割れる。`a^{p-1}` も `p ≥ 3` より `p²` で割れる。
+
+したがって、
+
+$$GN_p(a,b)\equiv p b^{p-1}\pmod{p^2}$$
+
+`p ∤ b` より右辺は `p²` で割れず、valuation は正確に一。
+
+#### Route B: LTE
+
+`c := a+b` とする。
+
+`p ∣ a = c-b`、`p ∤ b`、`p ∤ c` より、奇素数 LTE で
+
+$$v_p(c^p-b^p)=v_p(c-b)+v_p(p)=v_p(a)+1$$
+
+一方、
+
+$$c^p-b^p=a\,GN_p(a,b)$$
+
+なので valuation の加法性から、
+
+$$v_p(GN_p(a,b))=1$$
+
+となる。
+
+#### Selection rule
+
+```text
+prefer existing trusted LTE API if theorem matching is direct
+otherwise use explicit modulo-p² binomial route
+```
+
+一般化のために巨大な cyclotomic / algebraic-number dependency を追加しない。
+
+候補 theorem:
+
+```lean
+theorem padicValNat_GN_prime_exp_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
+```
+
+または factorization へ直接着地する。
+
+```lean
+theorem factorization_GN_prime_exp_eq_one_of_mem_support
+    {p a b : ℕ}
+    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∈ (GN p a b).factorization.support) :
+    (GN p a b).factorization p = 1
+```
+
+## 4. Fixed exponent five checkpoint
+
+一般 proof の前に、指数 `5` で theorem surface と sum closure を検証する。
+
+### 4.1. Arithmetic shape
+
+一般 GN の `p = 5` specialization は、局所座標で
+
+$$GN_5(a,b)=a^4+5a^3b+10a^2b^2+10ab^3+5b^4$$
+
+となる。
+
+mod `5` では、
+
+$$GN_5(a,b)\equiv a^4\pmod5$$
+
+`5 ∣ GN₅` なら `5 ∣ a`。
+
+mod `25` では `5 ∣ a` のもとで、
+
+$$GN_5(a,b)\equiv5b^4\pmod{25}$$
+
+`Coprime a b` より `5 ∤ b` なので、`25 ∤ GN₅`。
+
+### 4.2. Dependency boundary
+
+FLT5 側には同じ多項式観測があるが、ABC module から FLT module を import しない。
+
+許可するもの:
+
+```text
+read-only comparison with DkMath.FLT.Five.GN5
+reuse of a genuinely general theorem after moving it to the correct owner module
+```
+
+禁止するもの:
+
+```text
+DkMath.ABC -> DkMath.FLT.Five dependency
+copying a large FLT5 proof tower
+using FLT5 final theorem as arithmetic input
+```
+
+## 5. Sum closure
+
+局所 valuation theorem が得られた後、`GNExceptionalValuationExcess` を unfold する。
+
+```lean
+classical
+unfold GNExceptionalValuationExcess
+refine Finset.sum_eq_zero ?_
+intro q hq
+```
+
+`hq` を support membership と `q ∣ p` に分解し、`q = p` を得る。
+
+次に factorization multiplicity を一へ置換する。
+
+```text
+factorization q - 1 = 0
+real cast = 0
+summand = 0
+```
+
+`Real.log q` の評価や positivity は不要。multiplicity factor 自体がゼロになる。
+
+この設計により、解析層を一切使わず有限算術だけで M1 を閉じる。
+
+## 6. Budget bridge
+
+zero theorem から次を得る。
+
+```lean
+Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+```
+
+定義を展開すると目標は、
+
+$$0\le0\cdot\log\operatorname{rad}(abc)+0$$
+
+なので `simp` で閉じる。
+
+さらに split composition の caller-facing theorem を置く価値がある。
+
+```lean
+theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
+    (hexn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
+    GNValuationExcessBudgetAffine T p τn Dn
+```
+
+これは既存 `GNValuationExcessBudgetAffine.of_split` に zero exceptional budget を投入する薄い wrapper とする。
+
+最終 contract 全体をこの branch で再設計しない。
+
+## 7. Proposed modules
+
+### Preferred minimal layout
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+役割:
+
+```text
+odd-prime local valuation
+factorization multiplicity one
+exceptional finite sum zero
+zero affine budget
+split-budget wrapper
+```
+
+### Split layout, only if general GN arithmetic becomes reusable
+
+```text
+DkMath/NumberTheory/GN/OddPrimeExceptional.lean
+  general GN congruence and valuation-one results
+
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+  Triple wrapper, sum zero, budget bridge
+```
+
+新しい aggregator import は M1 theorem 完成後に判断する。
+
+## 8. Verification
+
+Focused build candidate:
+
+```text
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+```
+
+必要なら existing aggregate:
+
+```text
+lake build DkMath.ABC.GNFinalBudgetBridge
+```
+
+Axiom audit candidate:
+
+```lean
+#print axioms DkMath.ABC.Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+#print axioms DkMath.ABC.Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+```
+
+許容される標準依存:
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+## 9. Stop conditions
+
+次の場合は一般化を止め、固定指数 `5` の成果を確定して設計へ戻る。
+
+```text
+1. general LTE API requires a large unrelated dependency tower
+2. general binomial congruence causes broad refactoring
+3. theorem statement needs hidden assumptions not present in Triple
+4. p = 2 contaminates the odd-prime proof surface
+5. factorization/padic bridge is missing and requires a separate foundational module
+```
+
+固定 `5` theorem だけでも、`ABCGNFinalBudgetContract` の候補指数を `n = 5` と選ぶ route では M1 を完全消去できる。
+
+一般奇素数化は望ましいが、M1 討伐の必須条件ではない。
+
+## 10. Non-circularity audit
+
+M1 proof は次だけを使う。
+
+```text
+ABC triple coprimality
+GN binomial / difference-power identity
+prime divisibility
+p-adic valuation or square-divisibility
+finite factorization support
+```
+
+使ってはならないもの:
+
+```text
+ABC inequality
+abc_main_axiom
+uniform valuation budget assumption
+GNExceptionalExcessBudgetAffine as an input
+FLT5 no-solution theorem
+probabilistic or density assumptions
+```
+
+これにより、zero exceptional budget は最終 ABC contract の独立した算術入力として成立する。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-IMPLEMENTATION-DESIGN.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-IMPLEMENTATION-DESIGN.md
@@ -17,32 +17,60 @@ M1 の目的は、`n = p` が奇素数なら、この有限和が恒等的にゼ
 最終 theorem shape:
 
 ```lean
-/-- Odd-prime exponents carry no exponent-exceptional GN multiplicity. -/
 theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
     (T : Triple) {p : ℕ}
-    (hp : Nat.Prime p) (hpodd : 2 < p)
-    (ha : 0 < T.a) (hb : 0 < T.b) :
-    GNExceptionalValuationExcess p T.a T.b = 0 := by
-  ...
+    (hp : Nat.Prime p) (hpOdd : Odd p) :
+    GNExceptionalValuationExcess p T.a T.b = 0
 ```
 
 Budget wrapper:
 
 ```lean
-/-- The exceptional affine budget is exactly zero at odd-prime exponent. -/
 theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
     (T : Triple) {p : ℕ}
-    (hp : Nat.Prime p) (hpodd : 2 < p)
-    (ha : 0 < T.a) (hb : 0 < T.b) :
-    GNExceptionalExcessBudgetAffine T p 0 0 := by
-  ...
+    (hp : Nat.Prime p) (hpOdd : Odd p) :
+    GNExceptionalExcessBudgetAffine T p 0 0
 ```
 
-`hb` は GN nonzero や既存 API との接続に必要な場合のみ残す。不要なら theorem surface から除去する。
+M1-002〜004 の結果により positivity は不要である。
 
-## 2. Current API facts
+## 2. Mathematical reduction
 
-### 2.1. Boundary–GN overlap is exponent-supported
+Exceptional support 上の `q` は:
+
+```text
+q ∈ (GN p T.a T.b).factorization.support
+q ∣ p
+```
+
+を満たす。
+
+factorization support から `q.Prime`、さらに `p.Prime` と `q ∣ p` から:
+
+```text
+q = p
+```
+
+を得る。
+
+したがって M1 全体は次の一局所命題へ圧縮される。
+
+```text
+p ∣ GN p a b
+  -> (GN p a b).factorization p = 1
+```
+
+その後、各 exceptional summand は:
+
+```text
+((1 - 1 : ℕ) : ℝ) * Real.log p = 0
+```
+
+となる。
+
+## 3. Existing and completed API
+
+### 3.1. Boundary–GN overlap
 
 既存 theorem:
 
@@ -55,391 +83,334 @@ Triple.dvd_exp_of_dvd_boundary_of_dvd_GN
 
 $$q\mid T.a\quad\land\quad q\mid GN_n(T.a,T.b)\quad\Longrightarrow\quad q\mid n$$
 
-M1 では逆方向に近い局所事実を奇素数指数で作る。
+### 3.2. Prime-row GN congruence
 
-$$p\mid GN_p(T.a,T.b)\quad\Longrightarrow\quad p\mid T.a$$
-
-### 2.2. Exceptional excess is a filtered finite sum
-
-既存定義では、各 summand は
-
-$$\left(v_q(GN)-1\right)\log q$$
-
-である。
-
-したがって全体をゼロにする最短 route は、filtered support の各 `q` について
+`DkMath.NumberTheory.WeightedGNBridge` は:
 
 ```lean
-(GN p T.a T.b).factorization q = 1
+prime_exists_GN_eq_mul_add_rightBoundary
 ```
 
-を証明すること。
-
-### 2.3. Prime support facts
-
-`q ∈ m.factorization.support` から次が得られる。
+を供給する。
 
 ```text
-q is prime
-q ∣ m
-1 ≤ m.factorization q
+GN p a b = p * B + a^(p-1)
 ```
 
-既存補題:
-
-```lean
-one_le_factorization_of_mem_support
-```
-
-Mathlib 側の support / factorization prime lemmas を reconnaissance で確認し、独自補題を増やさない。
-
-## 3. Mathematical spine
-
-`a := T.a`、`b := T.b` と書く。
-
-一般 GN は、
-
-$$GN_p(a,b)=\frac{(a+b)^p-b^p}{a}$$
-
-に対応する。
-
-奇素数 `p` に対し、目標 chain は次。
-
-### 3.1. Exceptional support collapse
-
-`q` が exceptional support に属するなら、
+従って:
 
 ```text
-q ∈ factorization.support (GN p a b)
-q ∣ p
+p ∣ GN -> p ∣ a^(p-1) -> p ∣ a
 ```
 
-である。
-
-support から `q` は prime、`hp : Prime p` と `q ∣ p` から、
-
-$$q=p$$
-
-を得る。
-
-候補補題:
+M1-004 では次を完成した。
 
 ```lean
-theorem eq_exp_of_mem_exceptional_support_prime_exp
-    {p q a b : ℕ}
-    (hp : Nat.Prime p)
-    (hq : q ∈ (GN p a b).factorization.support)
-    (hqexp : q ∣ p) :
-    q = p
-```
-
-この補題は ABC triple に依存しない。
-
-### 3.2. Detection modulo p
-
-素数 `p` では中間二項係数が `p` で割れるため、
-
-$$GN_p(a,b)\equiv a^{p-1}\pmod p$$
-
-となる。
-
-したがって、
-
-$$p\mid GN_p(a,b)\Longrightarrow p\mid a^{p-1}\Longrightarrow p\mid a$$
-
-候補補題:
-
-```lean
-theorem prime_dvd_boundary_of_dvd_GN_prime_exp
+theorem prime_dvd_boundary_of_dvd_GN_prime
     {p a b : ℕ}
     (hp : Nat.Prime p)
     (hpGN : p ∣ GN p a b) :
     p ∣ a
 ```
 
-実装候補:
+### 3.3. GN/geometric quotient bridge
 
-1. general binomial coefficient congruence;
-2. an existing theorem about `gcd gap GN` specialized to prime exponent plus an additional nonzero argument;
-3. direct finite expansion only for the initial `p = 5` checkpoint.
-
-ここは reconnaissance の Outcome に応じて選ぶ。
-
-### 3.3. Coprime boundary removes p from b
-
-ABC triple では `T.hcop : Coprime T.a T.b` がある。
-
-$$p\mid a\quad\Longrightarrow\quad p\nmid b$$
-
-候補補題は新設せず、`Nat.Coprime` API を直接使う。
-
-### 3.4. Exact valuation one
-
-必要な局所定理は、
-
-$$p\mid GN_p(a,b)\Longrightarrow p^2\nmid GN_p(a,b)$$
-
-または同値な、
-
-$$v_p(GN_p(a,b))=1$$
-
-である。
-
-#### Route A: binomial modulo p²
-
-`p ∣ a`、`p ∤ b` とする。
-
-二項展開では、
-
-$$GN_p(a,b)=p b^{p-1}+\sum_{j=2}^{p-1}\binom pj a^{j-1}b^{p-j}+a^{p-1}$$
-
-中間項は `p` を係数に持ち、さらに `a` を一つ以上持つので `p²` で割れる。`a^{p-1}` も `p ≥ 3` より `p²` で割れる。
-
-したがって、
-
-$$GN_p(a,b)\equiv p b^{p-1}\pmod{p^2}$$
-
-`p ∤ b` より右辺は `p²` で割れず、valuation は正確に一。
-
-#### Route B: LTE
-
-`c := a+b` とする。
-
-`p ∣ a = c-b`、`p ∤ b`、`p ∤ c` より、奇素数 LTE で
-
-$$v_p(c^p-b^p)=v_p(c-b)+v_p(p)=v_p(a)+1$$
-
-一方、
-
-$$c^p-b^p=a\,GN_p(a,b)$$
-
-なので valuation の加法性から、
-
-$$v_p(GN_p(a,b))=1$$
-
-となる。
-
-#### Selection rule
-
-```text
-prefer existing trusted LTE API if theorem matching is direct
-otherwise use explicit modulo-p² binomial route
-```
-
-一般化のために巨大な cyclotomic / algebraic-number dependency を追加しない。
-
-候補 theorem:
+M1-004 は全自然数座標で:
 
 ```lean
-theorem padicValNat_GN_prime_exp_eq_one_of_dvd
+theorem GN_eq_geom_sum₂ (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b)^i * b^(p - 1 - i)
+```
+
+を証明した。
+
+`a ≠ 0` では `cosmic_id_csr` と `geom_sum₂_mul_add` の cancellation、`a = 0` では `GN_zero_eval` と `geom_sum₂_self` を使う。
+
+### 3.4. Odd-prime exact valuation
+
+M1-004 の主結果:
+
+```lean
+theorem padicValNat_GN_prime_eq_one_of_dvd
     {p a b : ℕ}
-    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
     (hcop : Nat.Coprime a b)
     (hpGN : p ∣ GN p a b) :
     padicValNat p (GN p a b) = 1
-```
 
-または factorization へ直接着地する。
-
-```lean
-theorem factorization_GN_prime_exp_eq_one_of_mem_support
+ theorem factorization_GN_prime_eq_one_of_dvd
     {p a b : ℕ}
-    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
     (hcop : Nat.Coprime a b)
-    (hpGN : p ∈ (GN p a b).factorization.support) :
+    (hpGN : p ∣ GN p a b) :
     (GN p a b).factorization p = 1
 ```
 
-## 4. Fixed exponent five checkpoint
+Proof route:
 
-一般 proof の前に、指数 `5` で theorem surface と sum closure を検証する。
+```text
+p ∣ GN
+  -> p ∣ a
+  -> Coprime a b gives p ∤ a+b
+  -> GN = geometric quotient
+  -> emultiplicity_geom_sum₂_eq_one over ℤ
+  -> Int/Nat multiplicity transfer
+  -> padicValNat = 1
+  -> factorization = 1
+```
 
-### 4.1. Arithmetic shape
+## 4. Fixed exponent five certificate
 
-一般 GN の `p = 5` specialization は、局所座標で
+M1-002 は一般 theorem とは独立に、指数 `5` の明示算術 certificate を作った。
 
 $$GN_5(a,b)=a^4+5a^3b+10a^2b^2+10ab^3+5b^4$$
 
-となる。
-
-mod `5` では、
+mod `5`:
 
 $$GN_5(a,b)\equiv a^4\pmod5$$
 
-`5 ∣ GN₅` なら `5 ∣ a`。
-
-mod `25` では `5 ∣ a` のもとで、
+`5 ∣ a` の下で mod `25`:
 
 $$GN_5(a,b)\equiv5b^4\pmod{25}$$
 
-`Coprime a b` より `5 ∤ b` なので、`25 ∤ GN₅`。
-
-### 4.2. Dependency boundary
-
-FLT5 側には同じ多項式観測があるが、ABC module から FLT module を import しない。
-
-許可するもの:
+`Coprime a b` より:
 
 ```text
-read-only comparison with DkMath.FLT.Five.GN5
-reuse of a genuinely general theorem after moving it to the correct owner module
+5 ∣ GN
+25 ∤ GN
+v_5(GN) = 1
 ```
 
-禁止するもの:
+この fixed-five proof は general multiplicity proof の regression certificate として残す。
+
+## 5. M1-005 finite-sum closure
+
+Preferred module:
 
 ```text
-DkMath.ABC -> DkMath.FLT.Five dependency
-copying a large FLT5 proof tower
-using FLT5 final theorem as arithmetic input
+DkMath/ABC/GNExceptionalExcessOddPrime.lean
 ```
 
-## 5. Sum closure
+Expected imports:
 
-局所 valuation theorem が得られた後、`GNExceptionalValuationExcess` を unfold する。
+```lean
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+```
+
+Target proof:
 
 ```lean
 classical
 unfold GNExceptionalValuationExcess
-refine Finset.sum_eq_zero ?_
+apply Finset.sum_eq_zero
 intro q hq
 ```
 
-`hq` を support membership と `q ∣ p` に分解し、`q = p` を得る。
-
-次に factorization multiplicity を一へ置換する。
+Then:
 
 ```text
-factorization q - 1 = 0
-real cast = 0
-summand = 0
+hq
+  -> hqSupport and hqDvdP
+  -> q.Prime
+  -> q = p
+  -> support gives p ∣ GN
+  -> factorization_GN_prime_eq_one_of_dvd hp hpOdd T.hcop hpGN
+  -> simp
 ```
 
-`Real.log q` の評価や positivity は不要。multiplicity factor 自体がゼロになる。
-
-この設計により、解析層を一切使わず有限算術だけで M1 を閉じる。
+No positivity hypotheses are required.
 
 ## 6. Budget bridge
 
-zero theorem から次を得る。
+Zero theoremから:
 
 ```lean
 Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
 ```
 
-定義を展開すると目標は、
+を thin wrapper として得る。
+
+定義展開後は:
 
 $$0\le0\cdot\log\operatorname{rad}(abc)+0$$
 
-なので `simp` で閉じる。
+となる。
 
-さらに split composition の caller-facing theorem を置く価値がある。
+Optional caller-facing wrapper:
 
 ```lean
 theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
-    (hexn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
+    (T : Triple) {p : ℕ} {τn Dn : ℝ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
     GNValuationExcessBudgetAffine T p τn Dn
 ```
 
-これは既存 `GNValuationExcessBudgetAffine.of_split` に zero exceptional budget を投入する薄い wrapper とする。
+これは:
 
-最終 contract 全体をこの branch で再設計しない。
+```lean
+GNValuationExcessBudgetAffine.of_split
+```
 
-## 7. Proposed modules
+へ exceptional zero budget と `hn` を投入する薄い theorem に限定する。
 
-### Preferred minimal layout
+## 7. Contract consequence
+
+M1 討伐前:
+
+```text
+σ + (τe + τn)
+```
+
+M1 討伐後:
+
+```text
+τe = 0
+De = 0
+σ + τn
+```
+
+したがって残る敵は:
+
+```text
+M2 lifted-radical support growth
+M3 non-exceptional valuation excess
+```
+
+## 8. Module ownership audit
+
+Current local arithmetic owner:
 
 ```text
 DkMath/ABC/GNOddPrimeExceptionalExcess.lean
 ```
 
-役割:
+次は ABC triple を主語にしない neutral theorem である。
 
-```text
-odd-prime local valuation
-factorization multiplicity one
-exceptional finite sum zero
-zero affine budget
-split-budget wrapper
+```lean
+GN_eq_geom_sum₂
+prime_dvd_boundary_of_dvd_GN_prime
 ```
 
-### Split layout, only if general GN arithmetic becomes reusable
+M1-006 で次を自己判断する。
 
 ```text
-DkMath/NumberTheory/GN/OddPrimeExceptional.lean
-  general GN congruence and valuation-one results
-
-DkMath/ABC/GNOddPrimeExceptionalExcess.lean
-  Triple wrapper, sum zero, budget bridge
+A. 現在の ABC owner を維持
+B. NumberTheory / CosmicFormula owner へ移動し ABC 側を薄くする
 ```
 
-新しい aggregator import は M1 theorem 完成後に判断する。
+移動は、再利用・依存方向・API discoverability の利得が churn を上回る場合だけ行う。
 
-## 8. Verification
+## 9. Verification
 
-Focused build candidate:
+Focused builds:
 
 ```text
 lake build DkMath.ABC.GNOddPrimeExceptionalExcess
-```
-
-必要なら existing aggregate:
-
-```text
+lake build DkMath.ABC.GNExceptionalExcessOddPrime
 lake build DkMath.ABC.GNFinalBudgetBridge
 ```
 
-Axiom audit candidate:
+Public aggregator を変更した場合のみ broader build を追加する。
+
+Axiom audit:
 
 ```lean
 #print axioms DkMath.ABC.Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
 #print axioms DkMath.ABC.Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
 ```
 
-許容される標準依存:
+Trust boundary:
 
 ```text
-propext
-Classical.choice
-Quot.sound
+no new axiom
+no sorry
+no native_decide
 ```
 
-## 9. Stop conditions
+## 10. Dual-Brain execution model
 
-次の場合は一般化を止め、固定指数 `5` の成果を確定して設計へ戻る。
+Codex と Wise Wolf は peer reasoning agents である。
 
 ```text
-1. general LTE API requires a large unrelated dependency tower
-2. general binomial congruence causes broad refactoring
-3. theorem statement needs hidden assumptions not present in Triple
-4. p = 2 contaminates the odd-prime proof surface
-5. factorization/padic bridge is missing and requires a separate foundational module
+not master/subordinate
+not planner/transcriber
+two search paths
+one Lean kernel judge
 ```
 
-固定 `5` theorem だけでも、`ABCGNFinalBudgetContract` の候補指数を `n = 5` と選ぶ route では M1 を完全消去できる。
+設計書は地図であり、固定命令列ではない。
 
-一般奇素数化は望ましいが、M1 討伐の必須条件ではない。
-
-## 10. Non-circularity audit
-
-M1 proof は次だけを使う。
+Codex は repository evidence に基づき:
 
 ```text
-ABC triple coprimality
-GN binomial / difference-power identity
-prime divisibility
-p-adic valuation or square-divisibility
-finite factorization support
+theorem name を改善
+module owner を変更
+micro-checkpoint を挿入
+機械的に連続する checkpoint を融合
+planned route より強い route を採用
 ```
 
-使ってはならないもの:
+できる。
+
+checkpoint は report と theorem surface を固定する監査点であり、permission gate ではない。
+
+完了後は:
 
 ```text
-ABC inequality
-abc_main_axiom
-uniform valuation budget assumption
-GNExceptionalExcessBudgetAffine as an input
-FLT5 no-solution theorem
-probabilistic or density assumptions
+result evaluation
+remaining Gap analysis
+next strongest action
+implementation
+verification
+report
+continued progression
 ```
 
-これにより、zero exceptional budget は最終 ABC contract の独立した算術入力として成立する。
+を自律的に続ける。
+
+M1-005 後は M1-006 integration/audit へ直ちに進む。
+
+## 11. Post-M1 route
+
+M1 完了後、Codex は M2/M3 の現在地を調査し、次の最大 leverage route を選定する。
+
+候補:
+
+```text
+M2 support-growth reconnaissance
+M3 non-exceptional depth reconnaissance
+support-depth combined tradeoff
+shared neutral valuation/support lemma
+```
+
+元の順序ではなく数学的 leverage で決める。
+
+Branch hygiene:
+
+```text
+M1 implementation remains in M1 branch
+M2/M3 implementation belongs to a new campaign branch
+neutral prerequisites may be factored when ownership is clear
+```
+
+## 12. Absolute boundaries
+
+```text
+no abc_main_axiom modification
+no ABC -> FLT.Five production dependency
+no FLT7 WIP dependency
+no unrelated refactor
+no new axiom
+no sorry
+no native_decide proof
+no finite enumeration as general proof
+```
+
+これらは trust/dependency invariant であり、主従関係による停止命令ではない。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-ROADMAP.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-ROADMAP.md
@@ -22,9 +22,9 @@ $$GNExceptionalExcessBudgetAffine\ T\ p\ 0\ 0$$
 ```text
 T : ABC Triple
 p : odd prime
-0 < T.a
-0 < T.b
 ```
+
+現在の実装結果から positivity は最終 theorem に不要と見込まれる。
 
 最小勝利条件:
 
@@ -41,16 +41,16 @@ p = 5 で上記二定理を完成
 ## 1. Checkpoint map
 
 ```text
-M1-000  campaign initialization
-M1-001  read-only theorem/API reconnaissance
-M1-002  exponent-five divisibility and no-lift kernel
-M1-003  exponent-five exceptional excess = 0
-M1-004  odd-prime general local valuation-one theorem
-M1-005  odd-prime exceptional excess = 0 and budget bridge
-M1-006  integration, audit, documentation closure
+M1-000  campaign initialization                              complete
+M1-001  read-only theorem/API reconnaissance                 complete / Outcome B
+M1-002  exponent-five divisibility and no-lift kernel        complete
+M1-003  exponent-five exceptional excess = 0                 complete / minimum victory
+M1-004  odd-prime general local valuation-one theorem        complete
+M1-005  odd-prime exceptional excess = 0 and budget bridge   active
+M1-006  integration, audit, documentation closure            autonomous continuation
 ```
 
-各 checkpoint は独立 commit と report を持たせる。大きな一般化を一つの commit に詰め込まない。
+各 checkpoint は theorem layer・focused verification・report を持つ。checkpoint は reviewable observation point であり、次 checkpoint へ進むための permission gate ではない。
 
 ## 2. M1-000: Campaign initialization
 
@@ -66,405 +66,356 @@ work branch
 Draft PR
 ```
 
-No Lean source change at this checkpoint.
-
 ## 3. M1-001: Read-only reconnaissance
 
-### Objective
+Status: **complete / Outcome B**
 
-実装前に、Mathlib と DkMath の既存 API で次を確認する。
+調査結果:
 
 ```text
-A. GN p a b の general binomial representation
-B. prime exponent modulo-p congruence
-C. odd-prime LTE theorem availability and exact signature
-D. padicValNat and Nat.factorization equality bridge
-E. factorization supportから prime/dvd を得る canonical lemmas
-F. p = 5 specializationを一般 GN で簡約する最短 route
+fixed exponent five is immediate
+general odd-prime route requires one GN/geometric quotient bridge
+Mathlib emultiplicity_geom_sum₂_eq_one is the strongest endpoint
 ```
 
-### Required inspection targets
+選択 route:
 
 ```text
-DkMath/ABC/GNExceptionalSplit.lean
-DkMath/ABC/GNValuationExcess.lean
-DkMath/ABC/GNFinalBudgetBridge.lean
-DkMath/ABC/PadicValNat.lean
-DkMath/FLT/Five/GN5.lean                 read-only comparison
-DkMath/NumberTheory/Gcd/GN.lean
-CosmicFormulaBinom GN / GTail owner files
-Mathlib LTE / padicValNat / factorization APIs
-```
-
-### Outcome branches
-
-#### Outcome A: direct general route exists
-
-既存 LTE または binomial API で odd-prime theorem を直接構成できる。
-
-```text
-M1-002 may be folded into a smoke theorem
-proceed rapidly to M1-004
-```
-
-#### Outcome B: fixed five is easy, general route requires new local lemma
-
-```text
-complete M1-002 and M1-003 first
-then design one reusable general GN lemma for M1-004
-```
-
-#### Outcome C: foundational bridge missing
-
-例:
-
-```text
-padicValNat = factorization multiplicity bridge is absent
-GN prime-exponent congruence owner is unclear
-```
-
-この場合は小さな foundational checkpoint を挿入する。ABC final bridge や unrelated modules を変更しない。
-
-### Report
-
-```text
-report-M1-001.md
-```
-
-Report must record:
-
-```text
-selected proof route
-exact existing theorem names
-new theorem surface
-import boundary
-rejected alternatives and reason
+M1-002 fixed-five local kernel
+M1-003 fixed-five finite sum
+M1-004 general odd-prime local kernel
+M1-005 general finite sum
 ```
 
 ## 4. M1-002: Exponent-five local kernel
 
-### Objective
+Status: **complete**
 
-一般 `GN` の指数 `5` について、exceptional prime `5` の divisibility と no-lift を証明する。
-
-### Target theorem candidates
+完成 theorem:
 
 ```lean
-theorem five_dvd_boundary_of_dvd_GN_five
-    {a b : ℕ}
-    (h5GN : 5 ∣ GN 5 a b) :
-    5 ∣ a
-
-theorem not_twentyFive_dvd_GN_five_of_coprime
-    {a b : ℕ}
-    (hcop : Nat.Coprime a b)
-    (h5GN : 5 ∣ GN 5 a b) :
-    ¬ 25 ∣ GN 5 a b
-
-theorem padicValNat_five_GN_five_eq_one_of_dvd
-    {a b : ℕ}
-    (hcop : Nat.Coprime a b)
-    (h5GN : 5 ∣ GN 5 a b) :
-    padicValNat 5 (GN 5 a b) = 1
+five_dvd_boundary_of_dvd_GN_five
+not_twentyFive_dvd_GN_five_of_coprime
+padicValNat_five_GN_five_eq_one_of_dvd
+factorization_five_GN_five_eq_one_of_dvd
 ```
 
-Exact names may change after reconnaissance.
-
-### Proof obligations
+数学的鎖:
 
 ```text
-GN 5 a b mod 5 = a^4
-5 | GN -> 5 | a
-Coprime a b -> 5 ∤ b
-GN 5 a b mod 25 = 5*b^4 when 5 | a
-5 ∤ b -> 25 ∤ GN
+GN 5 a b ≡ a^4 mod 5
+5 ∣ GN -> 5 ∣ a
+GN 5 (5*k) b = 25*K + 5*b^4
+Coprime a b -> 25 ∤ GN
+therefore v_5(GN) = 1
 ```
 
-### Placement
-
-Prefer:
-
-```text
-DkMath/ABC/GNOddPrimeExceptionalExcess.lean
-```
-
-If arithmetic theorem is clearly reusable outside ABC:
-
-```text
-DkMath/NumberTheory/GN/OddPrimeExceptional.lean
-```
-
-### Stop gate
-
-Do not proceed to general prime until focused build passes.
-
-```text
-lake build <new module>
-```
+この明示算術 proof は M1-004 の一般 multiplicity proof と独立した certificate として維持する。
 
 ## 5. M1-003: Exponent-five exceptional excess zero
 
-### Objective
+Status: **complete / minimum victory**
 
-Local valuation-one theoremを、既存の filtered finite sumへ接続する。
-
-### Target
+完成 theorem:
 
 ```lean
-theorem Triple.GNExceptionalValuationExcess_five_eq_zero
-    (T : Triple)
-    (ha : 0 < T.a) (hb : 0 < T.b) :
-    GNExceptionalValuationExcess 5 T.a T.b = 0
+Triple.GNExceptionalValuationExcess_five_eq_zero
+Triple.GNExceptionalExcessBudgetAffine_five_zero
 ```
 
-Positivity assumptions are retained only if required by existing GN nonzero or valuation APIs.
+positivity assumptions: **none**
 
-### Sum proof plan
+結果:
 
 ```text
-unfold GNExceptionalValuationExcess
-for q in filtered support:
-  q prime
-  q | 5
-  therefore q = 5
-  factorization multiplicity at 5 = 1
-  q-summand = 0
-sum = 0
-```
-
-### Budget target
-
-```lean
-theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
-    (T : Triple)
-    (ha : 0 < T.a) (hb : 0 < T.b) :
-    GNExceptionalExcessBudgetAffine T 5 0 0
-```
-
-### Milestone decision
-
-M1-003 completion is already a mathematical victory for the `n = 5` ABC–GN final contract route.
-
-At this point:
-
-```text
-M1 minimum victory achieved
 τe = 0
 De = 0
 ```
 
-A checkpoint review must decide whether to continue immediately to general odd prime or seal the fixed-five theorem first.
-
 ## 6. M1-004: Odd-prime local valuation-one theorem
 
-### Objective
+Status: **complete**
 
-M1-002 の局所算術を任意の奇素数へ一般化する。
-
-### Preferred theorem
+一般 bridge:
 
 ```lean
-theorem padicValNat_GN_prime_exp_eq_one_of_dvd
+theorem GN_eq_geom_sum₂ (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i)
+```
+
+prime-row boundary theorem:
+
+```lean
+theorem prime_dvd_boundary_of_dvd_GN_prime
     {p a b : ℕ}
     (hp : Nat.Prime p)
-    (hpodd : 2 < p)
+    (hpGN : p ∣ GN p a b) :
+    p ∣ a
+```
+
+主結果:
+
+```lean
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
     (hcop : Nat.Coprime a b)
     (hpGN : p ∣ GN p a b) :
     padicValNat p (GN p a b) = 1
+
+ theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1
 ```
 
-Equivalent no-lift form is acceptable as the primitive theorem:
-
-```lean
-¬ p ^ 2 ∣ GN p a b
-```
-
-provided valuation exactness is then derived cleanly.
-
-### Proof route priority
+proof route:
 
 ```text
-1. existing odd-prime LTE API
-2. existing general binomial congruence API
-3. new minimal modulo-p² GN theorem
+prime row GN congruence
+  -> p ∣ GN implies p ∣ a
+  -> Coprime a b implies p ∤ a+b
+  -> GN = geometric quotient
+  -> emultiplicity_geom_sum₂_eq_one over ℤ
+  -> Nat emultiplicity
+  -> padicValNat = 1
+  -> factorization = 1
 ```
 
-Avoid a large polynomial or cyclotomic abstraction unless the proof genuinely requires it.
-
-### Validation examples
-
-Add small theorem examples or `example` blocks only when useful for type checking.
-
-```text
-p = 3
-p = 5
-p = 7
-```
-
-Do not use finite enumeration as proof of the general theorem.
+positivity assumptions: **none**
 
 ## 7. M1-005: Odd-prime excess zero and budget bridge
 
-### Objective
+Status: **active**
 
-一般 local theorem を既存 finite support sum と final budget API へ接続する。
+Objective:
 
-### Main targets
+一般 local theorem を exceptional finite support sum と final budget API へ接続する。
+
+Preferred module:
+
+```text
+DkMath/ABC/GNExceptionalExcessOddPrime.lean
+```
+
+Main targets:
 
 ```lean
 theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
     (T : Triple) {p : ℕ}
-    (hp : Nat.Prime p) (hpodd : 2 < p)
-    (ha : 0 < T.a) (hb : 0 < T.b) :
+    (hp : Nat.Prime p) (hpOdd : Odd p) :
     GNExceptionalValuationExcess p T.a T.b = 0
 
-theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+ theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
     (T : Triple) {p : ℕ}
-    (hp : Nat.Prime p) (hpodd : 2 < p)
-    (ha : 0 < T.a) (hb : 0 < T.b) :
+    (hp : Nat.Prime p) (hpOdd : Odd p) :
     GNExceptionalExcessBudgetAffine T p 0 0
 ```
 
-### Optional caller-facing wrapper
+Proof spine:
+
+```text
+q ∈ factorization.support.filter (fun q => q ∣ p)
+  -> q.Prime
+  -> q ∣ p
+  -> q = p
+  -> support membership gives p ∣ GN
+  -> factorization_GN_prime_eq_one_of_dvd
+  -> exceptional summand = 0
+  -> finite sum = 0
+```
+
+Optional caller-facing wrapper:
 
 ```lean
 theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
-    (hexn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
+    (hn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
     GNValuationExcessBudgetAffine T p τn Dn
 ```
 
-This wrapper must be a thin use of:
+Include only if it is a natural thin application of:
 
 ```lean
 GNValuationExcessBudgetAffine.of_split
 ```
 
-No duplication of final bridge proof.
+Contract consequence:
 
-### Contract impact
+```text
+σ + (τe + τn)
+  -> σ + τn
+```
 
-For odd-prime exponent `p`, the remaining margin simplifies from
+because:
 
-$$\sigma+(\tau_e+\tau_n)$$
-
-to
-
-$$\sigma+\tau_n$$
-
-because
-
-$$\tau_e=0$$
-
-and
-
-$$D_e=0$$
-
-This simplification should be documented, but the global ABC contract structure need not be changed in this branch.
+```text
+τe = 0
+De = 0
+```
 
 ## 8. M1-006: Integration and closure
 
-### Objective
+Status: **continue automatically after M1-005**
 
-M1 theorem を public route へ安全に接続し、討伐記録を閉じる。
+M1-006 is integration/audit, not a new deep arithmetic checkpoint.
 
-### Tasks
+Tasks:
 
 ```text
-1. decide aggregator import
-2. focused module build
-3. GNFinalBudgetBridge regression build
-4. axiom audit
-5. theorem statement audit
-6. dependency-direction audit
-7. final report
+1. decide aggregator/public import
+2. focused regression builds
+3. representative endpoint axiom audit
+4. theorem naming and statement audit
+5. dependency-direction audit
+6. fixed-five/general theorem coexistence
+7. neutral API ownership audit
 8. README status update
+9. FINAL_REPORT.md
 ```
 
-### Build gates
+Neutral ownership candidates:
+
+```lean
+GN_eq_geom_sum₂
+prime_dvd_boundary_of_dvd_GN_prime
+```
+
+Decision branches:
+
+```text
+A. keep in ABC because campaign-local ownership is adequate
+B. move to NumberTheory/CosmicFormula because reuse and dependency clarity justify churn
+```
+
+Do not refactor for aesthetics alone.
+
+Build surface:
 
 ```text
 lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+lake build DkMath.ABC.GNExceptionalExcessOddPrime
 lake build DkMath.ABC.GNFinalBudgetBridge
 ```
 
-Root `DkMath` build is optional unless import surface is changed.
+Root `DkMath` build is required only if public aggregator surface changes.
 
-### Axiom audit
+Axiom audit targets:
 
 ```lean
 #print axioms DkMath.ABC.Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
 #print axioms DkMath.ABC.Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
 ```
 
-No new:
-
-```text
-axiom
-sorry
-native_decide
-```
-
-### Final document
+Final report:
 
 ```text
 FINAL_REPORT.md
 ```
 
-Final report must include:
+must include:
 
 ```text
 exact theorem chain
-fixed-five result
-odd-prime result or stop boundary
+fixed-five certificate
+general odd-prime certificate
 budget-contract consequence
 imports and dependency graph
 build results
 axiom audit
 remaining M2/M3 state
+next-campaign recommendation
 ```
 
-## 9. Checkpoint discipline
+## 9. Dual-Brain autonomous checkpoint discipline
 
-Each implementation checkpoint follows:
+Codex and Wise Wolf are peer reasoning agents.
 
 ```text
-read-only reconnaissance
-  -> one local theorem target
-  -> focused build
+not master/subordinate
+not planner/transcriber
+two independent inference routes
+Lean kernel as common judge
+```
+
+The operating loop is:
+
+```text
+reconnaissance
+  -> theorem target
+  -> implementation
+  -> focused verification
   -> report
-  -> review
-  -> next instruction
+  -> self-evaluation
+  -> next strongest action
 ```
 
-Codex must not skip directly from M1-001 to final theorem without exposing the local valuation-one kernel.
+A review synchronizes and cross-checks the two brains. It does not grant permission to think or proceed.
 
-## 10. Branch boundaries
+After a checkpoint, Codex should autonomously determine:
 
 ```text
-feature/ABC-GN-valuation-excess-260724-v0
-  └─ wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
+what became Core
+what remains Gap
+whether the planned next checkpoint is still optimal
+whether a micro-checkpoint should be inserted
+whether two planned checkpoints can be safely fused
+whether theorem ownership or dependency direction should change
 ```
 
-Do not import or modify:
+Codex may alter the planned route when repository evidence supports the change. The report must explain the decision.
+
+Preserve auditability:
 
 ```text
-DkMath/FLT/Seven/**
-parallel WIP branches
-unmerged experimental work
+coherent theorem surface
+focused build
+checkpoint report
+no hidden leap over a deep unproved obligation
 ```
 
-Read-only comparison with FLT5 is allowed, but production dependency from ABC to FLT5 is forbidden.
+After M1-005, proceed into M1-006 automatically.
+
+After M1 completion, inspect M2/M3 and choose the next strongest action. Preserve branch hygiene: work belonging to a new campaign should be designed for a new branch instead of being mixed into M1.
+
+## 10. Trust and branch boundaries
+
+Absolute trust boundaries:
+
+```text
+no new axiom
+no sorry
+no native_decide proof
+no finite enumeration as a general proof
+```
+
+Dependency boundaries:
+
+```text
+no abc_main_axiom modification
+no ABC -> FLT.Five production dependency
+no DkMath/FLT/Seven/** import or modification
+no parallel WIP branch dependency
+no unrelated repository refactor
+```
+
+These are mathematical and repository invariants, not permission gates.
 
 ## 11. Victory condition
 
-### Minimum victory
+Minimum victory: **complete**
 
 ```text
 GNExceptionalValuationExcess 5 T.a T.b = 0
 GNExceptionalExcessBudgetAffine T 5 0 0
 ```
 
-### Complete victory
+Complete victory:
 
 ```text
 ∀ odd prime p,
@@ -474,7 +425,7 @@ GNExceptionalExcessBudgetAffine T 5 0 0
   GNExceptionalExcessBudgetAffine T p 0 0
 ```
 
-When complete, the ABC–GN final obstruction list becomes:
+After complete victory, the ABC–GN obstruction list becomes:
 
 ```text
 M1 exceptional valuation excess       defeated
@@ -482,4 +433,4 @@ M2 lifted-radical support growth       remains
 M3 non-exceptional valuation excess    remains
 ```
 
-討伐後は、M1 の証明を再び開かず、M2/M3 の support–depth tradeoff 戦線へ進む。
+M1 should then be treated as closed Core. Reopen only if later integration produces a concrete counterexample or dependency defect.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-ROADMAP.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-ROADMAP.md
@@ -46,8 +46,8 @@ M1-001  read-only theorem/API reconnaissance                 complete / Outcome 
 M1-002  exponent-five divisibility and no-lift kernel        complete
 M1-003  exponent-five exceptional excess = 0                 complete / minimum victory
 M1-004  odd-prime general local valuation-one theorem        complete
-M1-005  odd-prime exceptional excess = 0 and budget bridge   active
-M1-006  integration, audit, documentation closure            autonomous continuation
+M1-005  odd-prime exceptional excess = 0 and budget bridge   complete
+M1-006  integration, audit, documentation closure            complete
 ```
 
 各 checkpoint は theorem layer・focused verification・report を持つ。checkpoint は reviewable observation point であり、次 checkpoint へ進むための permission gate ではない。
@@ -192,7 +192,7 @@ positivity assumptions: **none**
 
 ## 7. M1-005: Odd-prime excess zero and budget bridge
 
-Status: **active**
+Status: **complete**
 
 Objective:
 
@@ -261,7 +261,7 @@ De = 0
 
 ## 8. M1-006: Integration and closure
 
-Status: **continue automatically after M1-005**
+Status: **complete**
 
 M1-006 is integration/audit, not a new deep arithmetic checkpoint.
 

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-ROADMAP.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-ROADMAP.md
@@ -1,0 +1,485 @@
+# ABC–GN M1 ROADMAP
+
+副題: 第一魔核 `uniform exceptional valuation excess` 討伐工程
+
+## 0. Campaign target
+
+最終 summit:
+
+```lean
+Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+```
+
+数学的到達点:
+
+$$GNExceptionalValuationExcess\ p\ T.a\ T.b=0$$
+
+$$GNExceptionalExcessBudgetAffine\ T\ p\ 0\ 0$$
+
+対象:
+
+```text
+T : ABC Triple
+p : odd prime
+0 < T.a
+0 < T.b
+```
+
+最小勝利条件:
+
+```text
+p = 5 で上記二定理を完成
+```
+
+完全勝利条件:
+
+```text
+任意の odd prime p で上記二定理を完成
+```
+
+## 1. Checkpoint map
+
+```text
+M1-000  campaign initialization
+M1-001  read-only theorem/API reconnaissance
+M1-002  exponent-five divisibility and no-lift kernel
+M1-003  exponent-five exceptional excess = 0
+M1-004  odd-prime general local valuation-one theorem
+M1-005  odd-prime exceptional excess = 0 and budget bridge
+M1-006  integration, audit, documentation closure
+```
+
+各 checkpoint は独立 commit と report を持たせる。大きな一般化を一つの commit に詰め込まない。
+
+## 2. M1-000: Campaign initialization
+
+Status: **complete**
+
+Deliverables:
+
+```text
+README.md
+ABC-GN-M1-IMPLEMENTATION-DESIGN.md
+ABC-GN-M1-ROADMAP.md
+work branch
+Draft PR
+```
+
+No Lean source change at this checkpoint.
+
+## 3. M1-001: Read-only reconnaissance
+
+### Objective
+
+実装前に、Mathlib と DkMath の既存 API で次を確認する。
+
+```text
+A. GN p a b の general binomial representation
+B. prime exponent modulo-p congruence
+C. odd-prime LTE theorem availability and exact signature
+D. padicValNat and Nat.factorization equality bridge
+E. factorization supportから prime/dvd を得る canonical lemmas
+F. p = 5 specializationを一般 GN で簡約する最短 route
+```
+
+### Required inspection targets
+
+```text
+DkMath/ABC/GNExceptionalSplit.lean
+DkMath/ABC/GNValuationExcess.lean
+DkMath/ABC/GNFinalBudgetBridge.lean
+DkMath/ABC/PadicValNat.lean
+DkMath/FLT/Five/GN5.lean                 read-only comparison
+DkMath/NumberTheory/Gcd/GN.lean
+CosmicFormulaBinom GN / GTail owner files
+Mathlib LTE / padicValNat / factorization APIs
+```
+
+### Outcome branches
+
+#### Outcome A: direct general route exists
+
+既存 LTE または binomial API で odd-prime theorem を直接構成できる。
+
+```text
+M1-002 may be folded into a smoke theorem
+proceed rapidly to M1-004
+```
+
+#### Outcome B: fixed five is easy, general route requires new local lemma
+
+```text
+complete M1-002 and M1-003 first
+then design one reusable general GN lemma for M1-004
+```
+
+#### Outcome C: foundational bridge missing
+
+例:
+
+```text
+padicValNat = factorization multiplicity bridge is absent
+GN prime-exponent congruence owner is unclear
+```
+
+この場合は小さな foundational checkpoint を挿入する。ABC final bridge や unrelated modules を変更しない。
+
+### Report
+
+```text
+report-M1-001.md
+```
+
+Report must record:
+
+```text
+selected proof route
+exact existing theorem names
+new theorem surface
+import boundary
+rejected alternatives and reason
+```
+
+## 4. M1-002: Exponent-five local kernel
+
+### Objective
+
+一般 `GN` の指数 `5` について、exceptional prime `5` の divisibility と no-lift を証明する。
+
+### Target theorem candidates
+
+```lean
+theorem five_dvd_boundary_of_dvd_GN_five
+    {a b : ℕ}
+    (h5GN : 5 ∣ GN 5 a b) :
+    5 ∣ a
+
+theorem not_twentyFive_dvd_GN_five_of_coprime
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    ¬ 25 ∣ GN 5 a b
+
+theorem padicValNat_five_GN_five_eq_one_of_dvd
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    padicValNat 5 (GN 5 a b) = 1
+```
+
+Exact names may change after reconnaissance.
+
+### Proof obligations
+
+```text
+GN 5 a b mod 5 = a^4
+5 | GN -> 5 | a
+Coprime a b -> 5 ∤ b
+GN 5 a b mod 25 = 5*b^4 when 5 | a
+5 ∤ b -> 25 ∤ GN
+```
+
+### Placement
+
+Prefer:
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+If arithmetic theorem is clearly reusable outside ABC:
+
+```text
+DkMath/NumberTheory/GN/OddPrimeExceptional.lean
+```
+
+### Stop gate
+
+Do not proceed to general prime until focused build passes.
+
+```text
+lake build <new module>
+```
+
+## 5. M1-003: Exponent-five exceptional excess zero
+
+### Objective
+
+Local valuation-one theoremを、既存の filtered finite sumへ接続する。
+
+### Target
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_five_eq_zero
+    (T : Triple)
+    (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNExceptionalValuationExcess 5 T.a T.b = 0
+```
+
+Positivity assumptions are retained only if required by existing GN nonzero or valuation APIs.
+
+### Sum proof plan
+
+```text
+unfold GNExceptionalValuationExcess
+for q in filtered support:
+  q prime
+  q | 5
+  therefore q = 5
+  factorization multiplicity at 5 = 1
+  q-summand = 0
+sum = 0
+```
+
+### Budget target
+
+```lean
+theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
+    (T : Triple)
+    (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+### Milestone decision
+
+M1-003 completion is already a mathematical victory for the `n = 5` ABC–GN final contract route.
+
+At this point:
+
+```text
+M1 minimum victory achieved
+τe = 0
+De = 0
+```
+
+A checkpoint review must decide whether to continue immediately to general odd prime or seal the fixed-five theorem first.
+
+## 6. M1-004: Odd-prime local valuation-one theorem
+
+### Objective
+
+M1-002 の局所算術を任意の奇素数へ一般化する。
+
+### Preferred theorem
+
+```lean
+theorem padicValNat_GN_prime_exp_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpodd : 2 < p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
+```
+
+Equivalent no-lift form is acceptable as the primitive theorem:
+
+```lean
+¬ p ^ 2 ∣ GN p a b
+```
+
+provided valuation exactness is then derived cleanly.
+
+### Proof route priority
+
+```text
+1. existing odd-prime LTE API
+2. existing general binomial congruence API
+3. new minimal modulo-p² GN theorem
+```
+
+Avoid a large polynomial or cyclotomic abstraction unless the proof genuinely requires it.
+
+### Validation examples
+
+Add small theorem examples or `example` blocks only when useful for type checking.
+
+```text
+p = 3
+p = 5
+p = 7
+```
+
+Do not use finite enumeration as proof of the general theorem.
+
+## 7. M1-005: Odd-prime excess zero and budget bridge
+
+### Objective
+
+一般 local theorem を既存 finite support sum と final budget API へ接続する。
+
+### Main targets
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNExceptionalValuationExcess p T.a T.b = 0
+
+theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p) (hpodd : 2 < p)
+    (ha : 0 < T.a) (hb : 0 < T.b) :
+    GNExceptionalExcessBudgetAffine T p 0 0
+```
+
+### Optional caller-facing wrapper
+
+```lean
+theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
+    (hexn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
+    GNValuationExcessBudgetAffine T p τn Dn
+```
+
+This wrapper must be a thin use of:
+
+```lean
+GNValuationExcessBudgetAffine.of_split
+```
+
+No duplication of final bridge proof.
+
+### Contract impact
+
+For odd-prime exponent `p`, the remaining margin simplifies from
+
+$$\sigma+(\tau_e+\tau_n)$$
+
+to
+
+$$\sigma+\tau_n$$
+
+because
+
+$$\tau_e=0$$
+
+and
+
+$$D_e=0$$
+
+This simplification should be documented, but the global ABC contract structure need not be changed in this branch.
+
+## 8. M1-006: Integration and closure
+
+### Objective
+
+M1 theorem を public route へ安全に接続し、討伐記録を閉じる。
+
+### Tasks
+
+```text
+1. decide aggregator import
+2. focused module build
+3. GNFinalBudgetBridge regression build
+4. axiom audit
+5. theorem statement audit
+6. dependency-direction audit
+7. final report
+8. README status update
+```
+
+### Build gates
+
+```text
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+lake build DkMath.ABC.GNFinalBudgetBridge
+```
+
+Root `DkMath` build is optional unless import surface is changed.
+
+### Axiom audit
+
+```lean
+#print axioms DkMath.ABC.Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+#print axioms DkMath.ABC.Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+```
+
+No new:
+
+```text
+axiom
+sorry
+native_decide
+```
+
+### Final document
+
+```text
+FINAL_REPORT.md
+```
+
+Final report must include:
+
+```text
+exact theorem chain
+fixed-five result
+odd-prime result or stop boundary
+budget-contract consequence
+imports and dependency graph
+build results
+axiom audit
+remaining M2/M3 state
+```
+
+## 9. Checkpoint discipline
+
+Each implementation checkpoint follows:
+
+```text
+read-only reconnaissance
+  -> one local theorem target
+  -> focused build
+  -> report
+  -> review
+  -> next instruction
+```
+
+Codex must not skip directly from M1-001 to final theorem without exposing the local valuation-one kernel.
+
+## 10. Branch boundaries
+
+```text
+feature/ABC-GN-valuation-excess-260724-v0
+  └─ wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
+```
+
+Do not import or modify:
+
+```text
+DkMath/FLT/Seven/**
+parallel WIP branches
+unmerged experimental work
+```
+
+Read-only comparison with FLT5 is allowed, but production dependency from ABC to FLT5 is forbidden.
+
+## 11. Victory condition
+
+### Minimum victory
+
+```text
+GNExceptionalValuationExcess 5 T.a T.b = 0
+GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+### Complete victory
+
+```text
+∀ odd prime p,
+  GNExceptionalValuationExcess p T.a T.b = 0
+
+∀ odd prime p,
+  GNExceptionalExcessBudgetAffine T p 0 0
+```
+
+When complete, the ABC–GN final obstruction list becomes:
+
+```text
+M1 exceptional valuation excess       defeated
+M2 lifted-radical support growth       remains
+M3 non-exceptional valuation excess    remains
+```
+
+討伐後は、M1 の証明を再び開かず、M2/M3 の support–depth tradeoff 戦線へ進む。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
@@ -11,13 +11,14 @@ wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
 ```text
 M1-000  complete
 M1-001  complete / Outcome B
-M1-002  active
+M1-002  complete
+M1-003  active
 ```
 
 Current instruction:
 
 ```text
-instruction-M1-002.md
+instruction-M1-003.md
 ```
 
 ## Read order
@@ -28,6 +29,9 @@ ABC-GN-M1-IMPLEMENTATION-DESIGN.md
 ABC-GN-M1-ROADMAP.md
 report-M1-001.md
 instruction-M1-002.md
+report-M1-002.md
+review-M1-002.md
+instruction-M1-003.md
 ```
 
 Repository paths are relative to:
@@ -36,41 +40,79 @@ Repository paths are relative to:
 lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/
 ```
 
-## Active objective
+## Completed local kernel
 
-Implement only the fixed exponent-five local kernel:
+M1-002 established:
 
 ```text
 5 ∣ GN 5 a b
   -> 5 ∣ a
-  -> Coprime a b gives 5 ∤ b
-  -> 25 ∤ GN 5 a b
+  -> Coprime a b gives 25 ∤ GN 5 a b
   -> padicValNat 5 (GN 5 a b) = 1
+  -> (GN 5 a b).factorization 5 = 1
 ```
 
-Preferred new module:
+Implementation:
 
 ```text
 lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
 ```
 
-## Stop boundary
-
-M1-002 ends after:
+Reviewed commit:
 
 ```text
-local valuation-one theorem
+3fa7baceb34f7b184168e68fb16b9d76bf4d122b
+```
+
+Decision:
+
+```text
+M1-002 fully accepted
+```
+
+## Active objective
+
+Connect the local factorization-one theorem to the existing exceptional filtered sum and exact zero budget.
+
+Preferred new module:
+
+```text
+lean/dk_math/DkMath/ABC/GNExceptionalExcessFive.lean
+```
+
+Required endpoints:
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_five_eq_zero
+    (T : Triple) :
+    GNExceptionalValuationExcess 5 T.a T.b = 0
+
+theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
+    (T : Triple) :
+    GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+No positivity assumptions should be introduced unless Lean genuinely requires them.
+
+## Stop boundary
+
+M1-003 ends after:
+
+```text
+finite exceptional sum = 0
+exact affine budget = 0
 focused build
-report-M1-002.md
+report-M1-003.md
 commit
 ```
 
 Do not automatically start:
 
 ```text
-M1-003 exceptional finite-sum closure
 M1-004 odd-prime generalization
+M1-005 odd-prime finite-sum closure
 M2 or M3 work
+aggregator/public import changes
 ```
 
 ## Forbidden scope
@@ -85,4 +127,4 @@ no axiom
 no native_decide
 ```
 
-The detailed implementation contract is `instruction-M1-002.md`.
+The detailed implementation contract is `instruction-M1-003.md`.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
@@ -12,13 +12,14 @@ wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
 M1-000  complete
 M1-001  complete / Outcome B
 M1-002  complete
-M1-003  active
+M1-003  complete / fixed-five minimum victory
+M1-004  active
 ```
 
 Current instruction:
 
 ```text
-instruction-M1-003.md
+instruction-M1-004.md
 ```
 
 ## Read order
@@ -28,10 +29,11 @@ README.md
 ABC-GN-M1-IMPLEMENTATION-DESIGN.md
 ABC-GN-M1-ROADMAP.md
 report-M1-001.md
-instruction-M1-002.md
 report-M1-002.md
 review-M1-002.md
-instruction-M1-003.md
+report-M1-003.md
+review-M1-003.md
+instruction-M1-004.md
 ```
 
 Repository paths are relative to:
@@ -40,9 +42,9 @@ Repository paths are relative to:
 lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/
 ```
 
-## Completed local kernel
+## Completed fixed-five victory
 
-M1-002 established:
+M1-002 established the local exponent-five valuation-one theorem:
 
 ```text
 5 ∣ GN 5 a b
@@ -52,65 +54,101 @@ M1-002 established:
   -> (GN 5 a b).factorization 5 = 1
 ```
 
+M1-003 connected it to the exceptional finite sum and exact affine budget:
+
+```lean
+Triple.GNExceptionalValuationExcess_five_eq_zero
+Triple.GNExceptionalExcessBudgetAffine_five_zero
+```
+
+Thus, at exponent five:
+
+```text
+τe = 0
+De = 0
+```
+
 Implementation:
 
 ```text
 lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+lean/dk_math/DkMath/ABC/GNExceptionalExcessFive.lean
 ```
 
-Reviewed commit:
+Reviewed commits:
 
 ```text
 3fa7baceb34f7b184168e68fb16b9d76bf4d122b
+8a9690b41be321fed2b15dc9d578512388322a0d
 ```
 
 Decision:
 
 ```text
 M1-002 fully accepted
+M1-003 fully accepted
 ```
 
 ## Active objective
 
-Connect the local factorization-one theorem to the existing exceptional filtered sum and exact zero budget.
-
-Preferred new module:
-
-```text
-lean/dk_math/DkMath/ABC/GNExceptionalExcessFive.lean
-```
+Generalize the local valuation-one theorem from exponent five to every odd prime exponent.
 
 Required endpoints:
 
 ```lean
-theorem Triple.GNExceptionalValuationExcess_five_eq_zero
-    (T : Triple) :
-    GNExceptionalValuationExcess 5 T.a T.b = 0
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
 
-theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
-    (T : Triple) :
-    GNExceptionalExcessBudgetAffine T 5 0 0
+theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1
+```
+
+Primary route:
+
+```text
+p ∣ GN -> p ∣ a
+Coprime a b -> p ∤ a+b
+GN = geometric quotient
+emultiplicity_geom_sum₂_eq_one
+transfer to padicValNat / factorization
+```
+
+Alternative route:
+
+```text
+odd-prime LTE on (a+b)^p - b^p
+plus the exact boundary * GN product split
 ```
 
 No positivity assumptions should be introduced unless Lean genuinely requires them.
 
 ## Stop boundary
 
-M1-003 ends after:
+M1-004 ends after:
 
 ```text
-finite exceptional sum = 0
-exact affine budget = 0
+odd-prime local valuation-one theorem
+odd-prime local factorization-one theorem
 focused build
-report-M1-003.md
+report-M1-004.md
 commit
 ```
 
 Do not automatically start:
 
 ```text
-M1-004 odd-prime generalization
-M1-005 odd-prime finite-sum closure
+M1-005 odd-prime exceptional finite-sum closure
+M1-006 integration/audit closure
 M2 or M3 work
 aggregator/public import changes
 ```
@@ -125,6 +163,7 @@ no unrelated refactor
 no sorry
 no axiom
 no native_decide
+no finite enumeration as general proof
 ```
 
-The detailed implementation contract is `instruction-M1-003.md`.
+The detailed implementation contract is `instruction-M1-004.md`.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
@@ -1,0 +1,88 @@
+# Codex Start Entry — ABC–GN M1 Active
+
+作業 branch:
+
+```text
+wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
+```
+
+## Status
+
+```text
+M1-000  complete
+M1-001  complete / Outcome B
+M1-002  active
+```
+
+Current instruction:
+
+```text
+instruction-M1-002.md
+```
+
+## Read order
+
+```text
+README.md
+ABC-GN-M1-IMPLEMENTATION-DESIGN.md
+ABC-GN-M1-ROADMAP.md
+report-M1-001.md
+instruction-M1-002.md
+```
+
+Repository paths are relative to:
+
+```text
+lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/
+```
+
+## Active objective
+
+Implement only the fixed exponent-five local kernel:
+
+```text
+5 ∣ GN 5 a b
+  -> 5 ∣ a
+  -> Coprime a b gives 5 ∤ b
+  -> 25 ∤ GN 5 a b
+  -> padicValNat 5 (GN 5 a b) = 1
+```
+
+Preferred new module:
+
+```text
+lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+## Stop boundary
+
+M1-002 ends after:
+
+```text
+local valuation-one theorem
+focused build
+report-M1-002.md
+commit
+```
+
+Do not automatically start:
+
+```text
+M1-003 exceptional finite-sum closure
+M1-004 odd-prime generalization
+M2 or M3 work
+```
+
+## Forbidden scope
+
+```text
+no abc_main_axiom modification
+no ABC -> FLT.Five production import
+no FLT7 work
+no unrelated refactor
+no sorry
+no axiom
+no native_decide
+```
+
+The detailed implementation contract is `instruction-M1-002.md`.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/CODEX_START.md
@@ -1,4 +1,4 @@
-# Codex Start Entry — ABC–GN M1 Active
+# Codex Start Entry — ABC–GN M1 Dual-Brain Campaign
 
 作業 branch:
 
@@ -13,14 +13,43 @@ M1-000  complete
 M1-001  complete / Outcome B
 M1-002  complete
 M1-003  complete / fixed-five minimum victory
-M1-004  active
+M1-004  complete / odd-prime local valuation-one
+M1-005  active / odd-prime exceptional sum and zero budget
+M1-006  autonomous continuation after M1-005
 ```
 
 Current instruction:
 
 ```text
-instruction-M1-004.md
+instruction-M1-005.md
 ```
+
+## Dual-Brain operating doctrine
+
+Codex and Wise Wolf are peer reasoning agents over the same Lean-verified research program.
+
+```text
+not master and subordinate
+not planner and transcription engine
+two reasoning brains with different search paths
+```
+
+A checkpoint is an auditable observation point, not a permission gate.
+
+After a checkpoint is completed, Codex should:
+
+```text
+evaluate the mathematical result
+inspect the changed theorem and dependency surface
+identify the remaining Gap
+choose the strongest next action
+continue implementation and verification
+record a checkpoint report
+```
+
+Do not wait for a new instruction merely because the planned endpoint has been reached. Preserve coherent reports and reviewable theorem layers so the second brain can audit the route afterward.
+
+Repository publication operations remain user-controlled unless separately requested.
 
 ## Read order
 
@@ -33,7 +62,9 @@ report-M1-002.md
 review-M1-002.md
 report-M1-003.md
 review-M1-003.md
-instruction-M1-004.md
+report-M1-004.md
+review-M1-004.md
+instruction-M1-005.md
 ```
 
 Repository paths are relative to:
@@ -44,7 +75,7 @@ lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/
 
 ## Completed fixed-five victory
 
-M1-002 established the local exponent-five valuation-one theorem:
+M1-002 established:
 
 ```text
 5 ∣ GN 5 a b
@@ -54,46 +85,42 @@ M1-002 established the local exponent-five valuation-one theorem:
   -> (GN 5 a b).factorization 5 = 1
 ```
 
-M1-003 connected it to the exceptional finite sum and exact affine budget:
+M1-003 connected the local kernel to the exceptional finite sum and exact affine budget:
 
 ```lean
 Triple.GNExceptionalValuationExcess_five_eq_zero
 Triple.GNExceptionalExcessBudgetAffine_five_zero
 ```
 
-Thus, at exponent five:
+Thus at exponent five:
 
 ```text
 τe = 0
 De = 0
 ```
 
-Implementation:
+## Completed odd-prime local kernel
 
-```text
-lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
-lean/dk_math/DkMath/ABC/GNExceptionalExcessFive.lean
+M1-004 established the general geometric quotient bridge:
+
+```lean
+theorem GN_eq_geom_sum₂ (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i)
 ```
 
-Reviewed commits:
+and the prime-row boundary extraction:
 
-```text
-3fa7baceb34f7b184168e68fb16b9d76bf4d122b
-8a9690b41be321fed2b15dc9d578512388322a0d
+```lean
+theorem prime_dvd_boundary_of_dvd_GN_prime
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpGN : p ∣ GN p a b) :
+    p ∣ a
 ```
 
-Decision:
-
-```text
-M1-002 fully accepted
-M1-003 fully accepted
-```
-
-## Active objective
-
-Generalize the local valuation-one theorem from exponent five to every odd prime exponent.
-
-Required endpoints:
+The main local endpoints are:
 
 ```lean
 theorem padicValNat_GN_prime_eq_one_of_dvd
@@ -104,7 +131,7 @@ theorem padicValNat_GN_prime_eq_one_of_dvd
     (hpGN : p ∣ GN p a b) :
     padicValNat p (GN p a b) = 1
 
-theorem factorization_GN_prime_eq_one_of_dvd
+ theorem factorization_GN_prime_eq_one_of_dvd
     {p a b : ℕ}
     (hp : Nat.Prime p)
     (hpOdd : Odd p)
@@ -113,52 +140,100 @@ theorem factorization_GN_prime_eq_one_of_dvd
     (GN p a b).factorization p = 1
 ```
 
-Primary route:
+Proof route:
 
 ```text
-p ∣ GN -> p ∣ a
-Coprime a b -> p ∤ a+b
-GN = geometric quotient
-emultiplicity_geom_sum₂_eq_one
-transfer to padicValNat / factorization
+p ∣ GN
+  -> p ∣ a
+  -> Coprime a b gives p ∤ a+b
+  -> GN = geometric quotient
+  -> emultiplicity_geom_sum₂_eq_one over ℤ
+  -> Nat emultiplicity
+  -> padicValNat = 1
+  -> factorization = 1
 ```
 
-Alternative route:
+Reviewed commit:
 
 ```text
-odd-prime LTE on (a+b)^p - b^p
-plus the exact boundary * GN product split
+97c1558f883cc1f9ef56b81bd64940b64a09ba6b
 ```
 
-No positivity assumptions should be introduced unless Lean genuinely requires them.
-
-## Stop boundary
-
-M1-004 ends after:
+Decision:
 
 ```text
-odd-prime local valuation-one theorem
-odd-prime local factorization-one theorem
-focused build
-report-M1-004.md
-commit
+M1-004 fully accepted
 ```
 
-Do not automatically start:
+## Active objective
+
+Close the general odd-prime exceptional filtered sum and exact zero budget.
+
+Expected module:
 
 ```text
-M1-005 odd-prime exceptional finite-sum closure
-M1-006 integration/audit closure
-M2 or M3 work
-aggregator/public import changes
+lean/dk_math/DkMath/ABC/GNExceptionalExcessOddPrime.lean
 ```
 
-## Forbidden scope
+Expected endpoints:
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalValuationExcess p T.a T.b = 0
+
+ theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalExcessBudgetAffine T p 0 0
+```
+
+No positivity assumptions are expected.
+
+Proof spine:
+
+```text
+q in exceptional factorization support
+  -> q.Prime
+  -> q ∣ p
+  -> q = p
+  -> support gives p ∣ GN
+  -> M1-004 gives factorization p = 1
+  -> summand = 0
+  -> exceptional sum = 0
+  -> exact affine budget (0,0)
+```
+
+## Autonomous continuation
+
+After M1-005, continue directly into M1-006 integration and closure.
+
+M1-006 should self-evaluate:
+
+```text
+aggregator/public import
+focused regression builds
+axiom audit
+theorem naming and statement audit
+dependency direction
+fixed-five/general theorem coexistence
+neutral ownership of GN_eq_geom_sum₂ and prime boundary theorem
+README / FINAL_REPORT closure
+```
+
+Do not refactor neutral API merely because another owner looks aesthetically cleaner. Move only when reuse and dependency ownership materially improve.
+
+After M1 is completely closed, inspect M2/M3 and prepare the strongest next campaign route while preserving branch hygiene.
+
+## Hard boundaries
 
 ```text
 no abc_main_axiom modification
 no ABC -> FLT.Five production import
-no FLT7 work
+no FLT7 WIP work
 no unrelated refactor
 no sorry
 no axiom
@@ -166,4 +241,4 @@ no native_decide
 no finite enumeration as general proof
 ```
 
-The detailed implementation contract is `instruction-M1-004.md`.
+These are mathematical trust and repository dependency boundaries, not permission gates.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/FINAL_REPORT.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/FINAL_REPORT.md
@@ -1,0 +1,188 @@
+# ABC–GN M1 Final Report
+
+Date: 2026-07-26  
+Status: **M1 complete — odd-prime exceptional valuation excess defeated**
+
+## 1. 最終数学結果
+
+任意の ABC triple `T` と奇素数 `p` について:
+
+```lean
+Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+```
+
+が次を与える。
+
+$$
+GNExceptionalValuationExcess\ p\ T.a\ T.b=0.
+$$
+
+さらに:
+
+```lean
+Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+```
+
+により:
+
+```text
+τe = 0
+De = 0
+```
+
+が exact に供給される。positivity 仮定は不要である。
+
+## 2. 完成 theorem chain
+
+```text
+GN_eq_geom_sum₂
+  -> prime_dvd_boundary_of_dvd_GN_prime
+  -> padicValNat_GN_prime_eq_one_of_dvd
+  -> factorization_GN_prime_eq_one_of_dvd
+  -> Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+  -> Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+  -> Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
+```
+
+数学的には:
+
+```text
+q in exceptional support
+  -> q.Prime and q ∣ p
+  -> q = p
+  -> p ∣ GN
+  -> p-adic valuation of GN = 1
+  -> exceptional multiplicity excess = 0
+```
+
+である。
+
+## 3. Fixed-five certificate との共存
+
+固定指数 5 の theorem:
+
+```lean
+Triple.GNExceptionalValuationExcess_five_eq_zero
+Triple.GNExceptionalExcessBudgetAffine_five_zero
+```
+
+は維持した。
+
+```text
+fixed five:
+  explicit modulo 5 / modulo 25 certificate
+
+general odd prime:
+  geometric quotient / emultiplicity certificate
+```
+
+という独立した二経路であり、固定五は有用な regression certificate である。
+
+## 4. Module / dependency surface
+
+```text
+DkMath.NumberTheory.WeightedGNBridge
+  -> DkMath.ABC.GNOddPrimeExceptionalExcess
+  -> DkMath.ABC.GNExceptionalExcessOddPrime
+
+DkMath.ABC.GNFinalBudgetBridge
+  -> DkMath.ABC.GNExceptionalExcessOddPrime
+
+DkMath.ABC
+  -> DkMath.ABC.GNExceptionalExcessOddPrime
+```
+
+production dependency に `DkMath.FLT.Five.*` や FLT7 WIP はない。
+
+`GN_eq_geom_sum₂` と `prime_dvd_boundary_of_dvd_GN_prime` は neutral 化可能
+だが、現状でも依存方向は正しく、直近の再利用 caller は M1 内だけである。
+移動は churn と import 変更を発生させるため、M1-006 では現在位置を維持
+した。将来、ABC 外の複数 caller が現れた時点で neutral owner を再評価する。
+
+## 5. Public integration
+
+公開入口:
+
+```lean
+import DkMath.ABC
+```
+
+から一般 odd-prime endpoint を利用できるよう、
+`DkMath/ABC.lean` に:
+
+```lean
+import DkMath.ABC.GNExceptionalExcessOddPrime
+```
+
+を追加した。
+
+## 6. Contract reduction
+
+従来の full valuation split:
+
+```text
+exceptional coefficient/constant + non-exceptional coefficient/constant
+```
+
+は奇素数指数で:
+
+```text
+0 + non-exceptional coefficient/constant
+```
+
+へ縮退する。
+
+caller-facing theorem により、次だけを供給すればよい。
+
+```lean
+GNNonExceptionalExcessBudgetAffine T p τn Dn
+```
+
+すると損失なく:
+
+```lean
+GNValuationExcessBudgetAffine T p τn Dn
+```
+
+を得る。
+
+## 7. Trust audit
+
+実行した regression build:
+
+```text
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+  DkMath.ABC.GNExceptionalExcessFive
+  DkMath.ABC.GNExceptionalExcessOddPrime
+  DkMath.ABC.GNFinalBudgetBridge
+  DkMath.ABC
+
+Build completed successfully (8377 jobs).
+
+lake build DkMath
+Build completed successfully (8746 jobs).
+```
+
+代表 endpoint 3 本の axiom audit では、Lean / Mathlib の標準依存:
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+のみを許容する。新規 project axiom、`sorry`、`native_decide`、有限列挙に
+よる一般証明はない。
+
+## 8. M1 closure
+
+```text
+M1 exceptional valuation excess       defeated
+M2 lifted-radical support growth       remains
+M3 non-exceptional valuation excess    remains
+```
+
+M1 は閉じた Core とする。再度開く条件は、後続 integration で具体的な
+counterexample、型不整合、依存欠陥が発見された場合に限る。
+
+M2/M3 の実装は branch hygiene を守り、専用 campaign branch で開始する。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/NEXT_CAMPAIGN.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/NEXT_CAMPAIGN.md
@@ -1,0 +1,137 @@
+# ABC–GN Next Campaign Reconnaissance
+
+Date: 2026-07-26  
+Status: **design only / start on a separate campaign branch**
+
+## 1. 戦況
+
+M1 により、奇素数指数 `p` の exceptional valuation excess は exact に消えた。
+
+```text
+τe = 0
+De = 0
+```
+
+したがって `GNFinalBudgetBridge` に残る本質的な入力は次の二つである。
+
+```text
+M2  lifted-radical support growth
+M3  non-exceptional valuation excess
+```
+
+本ノートは M2/M3 の theorem を追加しない。現在の M1 branch を閉じたまま、
+次 campaign の最初の checkpoint を定めるための reconnaissance である。
+
+## 2. 既存 API が与える境界
+
+### M2: support
+
+既存の budget interface は:
+
+```lean
+GNLiftRadicalGrowthBudgetAffine
+```
+
+であり、そこから:
+
+```lean
+Triple.nonExceptionalSupportBudgetAffine_of_liftGrowth
+Triple.GNSupportBudgetAffine_of_liftGrowth
+```
+
+へ決定論的に輸送できる。
+
+一方、primitive divisor / Zsigmondy 型の既存結果が直接与えるのは、典型的には
+fresh prime の**存在または下界方向**である。必要な uniform support budget は
+総 support の**上界方向**なので、この存在定理だけでは M2 は閉じない。
+
+### M3: multiplicity
+
+既存 API は high-lift locus を有限 support として正確に切り出している。
+
+```lean
+GNHighLiftPrime
+GNNonExceptionalHighLiftPrime
+highLiftSupport
+valuationExcess_eq_sum_highLift
+GNValuationExcess_eq_sum_highLift
+GNValuationExcess_eq_zero_of_no_highLift
+Triple.nonExceptionalHighLift_not_dvd_boundary
+two_le_padicValNat_GN_of_highLift
+padicValNat_GN_le_one_of_noHighLift
+Triple.padic_powerDiff_le_one_of_nonExceptional_noHighLift
+```
+
+しかしこの API は high-lift prime の global rarity や uniform depth bound を
+主張しない。M3 を単独で一様化する正面攻撃は、Wieferich/Hensel 型の
+multiplicity 現象を直接扱うことになる。
+
+## 3. 推奨する次戦線
+
+最終 contract が必要とするのは M2 と M3 の個別最強定理ではなく、最終指数の
+margin に収まる**合成予算**である。従って次 campaign は:
+
+```text
+support mass + multiplicity excess
+```
+
+を同じ有限 prime support 上で扱う joint support–multiplicity campaign とする。
+
+出発点には既存の exact identity:
+
+```lean
+log_eq_log_rad_add_valuationExcess
+```
+
+および `GNValuationExcess_eq_sum_highLift` を使う。目標は、radical support と
+high-lift depth を別々に過大評価せず、`log (GN ...)` の中で再結合した量を
+最終 budget へ輸送できる最小 API を同定することである。
+
+これは joint bound が既に証明可能だという主張ではない。M2/M3 の独立 uniform
+bound より弱く、かつ `GNFinalBudgetBridge` に十分な命題が存在するかを最初に
+監査する方針である。
+
+## 4. 次 campaign の checkpoint 案
+
+### JSM-001: Exact accounting audit
+
+- `log_eq_log_rad_add_valuationExcess` の型と positivity 条件を固定する。
+- `GNValuationExcess_eq_sum_highLift` と同一 support 上で書ける正確な恒等式を
+  inventory する。
+- M1 の exceptional zero を代入し、odd-prime non-exceptional normal form を得る。
+- 新しい一様評価、解析的仮定、axiom は導入しない。
+
+### JSM-002: Minimal combined budget contract
+
+- `GNFinalBudgetBridge` が実際に必要とする合成係数・定数を逆算する。
+- M2/M3 の個別 contract より弱い joint contract を定義できるか判定する。
+- 既存 contract から joint contract への transport と、joint contract から
+  final bridge への transport を分離する。
+
+### JSM-003: Arithmetic obstruction audit
+
+- primitive-divisor 情報が joint quantity のどの項に効くか確認する。
+- high-lift depth が support growth と相殺または再配分可能か確認する。
+- uniform theorem が得られなければ、未解決算術 input を exact obligation として
+  文書化し、Lean 上の reduction theorem だけを閉じる。
+
+## 5. Victory condition
+
+次 campaign の勝利条件は、次のいずれかである。
+
+```text
+A. final bridge に十分な joint affine budget を無条件に証明する
+B. 既存算術結果から joint budget への canonical reduction theorem を証明する
+C. 不可能な強化を避け、残る外部算術 obligation を exact な Lean proposition
+   として最小化する
+```
+
+`C` は ABC そのものの証明ではないが、形式化としては honest な前線固定である。
+
+## 6. Branch hygiene
+
+- M1 branch では設計記録だけを残し、M2/M3 実装を開始しない。
+- 次 campaign は専用 branch と専用 checkpoint 文書から開始する。
+- `abc_main_axiom`、FLT5/FLT7 WIP、`sorry`、新規 axiom、`native_decide`、
+  有限列挙による一般証明に依存しない。
+- M1 の一般 odd-prime endpoint を閉じた Core として import する。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/README.md
@@ -1,7 +1,7 @@
 # ABC–GN M1: Odd-Prime Exponent Exceptional Excess
 
 作成日: 2026-07-25  
-Status: **M1-004 complete / M1-005 active / autonomous continuation enabled**
+Status: **M1 complete / odd-prime exceptional excess defeated**
 
 Repository: `Deskuma/dkmath`  
 Base branch: `feature/ABC-GN-valuation-excess-260724-v0`  
@@ -43,8 +43,8 @@ M1-001  theorem/API reconnaissance                           complete / Outcome 
 M1-002  exponent-five divisibility and no-lift kernel        complete
 M1-003  exponent-five exceptional excess = 0                 complete / minimum victory
 M1-004  odd-prime general local valuation-one theorem        complete
-M1-005  odd-prime exceptional excess = 0 and budget bridge   active
-M1-006  integration, audit, documentation closure            follows autonomously
+M1-005  odd-prime exceptional excess = 0 and budget bridge   complete
+M1-006  integration, audit, documentation closure            complete
 ```
 
 ## 3. Existing deterministic spine
@@ -156,11 +156,11 @@ theorem padicValNat_GN_prime_eq_one_of_dvd
 
 この theorem も positivity を必要としない。
 
-## 6. Active M1-005
+## 6. Completed odd-prime victory
 
-一般奇素数の local factorization-one theorem を exceptional finite sum へ接続する。
+一般奇素数の local factorization-one theorem を exceptional finite sum へ接続した。
 
-目標:
+完成 theorem:
 
 ```lean
 theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
@@ -188,6 +188,15 @@ q in exceptional support
   -> summand = 0
   -> finite sum = 0
 ```
+
+さらに非例外 budget だけから full valuation budget を供給する production-facing
+wrapper も完成した。
+
+```lean
+Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
+```
+
+公開入口 `DkMath.ABC` は `GNExceptionalExcessOddPrime` を import する。
 
 ## 7. Dual-Brain campaign doctrine
 
@@ -223,7 +232,8 @@ checkpoint report
 reviewable change boundary
 ```
 
-M1-005 完了後は M1-006 integration/audit へ連続進行し、M1 閉鎖後は M2/M3 の次戦線を調査・設計する。
+M1-005 と M1-006 は完了した。M1 は閉じた Core とし、次戦線は M2/M3
+専用 campaign で扱う。
 
 ## 8. Planned implementation surface
 

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/README.md
@@ -1,0 +1,226 @@
+# ABC–GN M1: Odd-Prime Exponent Exceptional Excess
+
+作成日: 2026-07-25  
+Status: **WIP / campaign initialized**
+
+Repository: `Deskuma/dkmath`  
+Base branch: `feature/ABC-GN-valuation-excess-260724-v0`  
+Work branch: `wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0`
+
+## 1. Mission
+
+ABC–GN deterministic spine が残した三つの一様予算のうち、第一魔核 M1 を討伐する。
+
+```text
+M1  uniform exponent-exceptional valuation excess
+M2  uniform lifted-radical support growth
+M3  uniform non-exceptional valuation excess
+```
+
+本プロジェクトの目標は、指数を奇素数 `p` に固定したとき、指数例外 prime channel の valuation excess が完全に消えることを Lean で証明することである。
+
+最終目標は、正の ABC triple `T` と奇素数 `p` に対して次を得ること。
+
+$$GNExceptionalValuationExcess\ p\ T.a\ T.b=0$$
+
+その結果、既存の exceptional affine budget を係数・定数ともにゼロで供給する。
+
+```lean
+GNExceptionalExcessBudgetAffine T p 0 0
+```
+
+すなわち、最終 budget contract の第一成分を
+
+```text
+τe = 0
+De = 0
+```
+
+へ固定する。
+
+## 2. Existing deterministic spine
+
+基底ブランチには、次の構造が既に実装されている。
+
+```text
+DkMath/ABC/GNExceptionalSplit.lean
+  Triple.gcd_boundary_GN_dvd_exp
+  Triple.dvd_exp_of_dvd_boundary_of_dvd_GN
+  Triple.not_dvd_boundary_of_not_dvd_exp_of_dvd_GN
+
+DkMath/ABC/GNValuationExcess.lean
+  GNExceptionalValuationExcess
+  GNNonExceptionalValuationExcess
+  GNValuationExcess_eq_exceptional_add_nonExceptional
+
+DkMath/ABC/GNFinalBudgetBridge.lean
+  GNExceptionalExcessBudgetAffine
+  GNNonExceptionalExcessBudgetAffine
+  GNValuationExcessBudgetAffine.of_split
+  ABCGNFinalBudgetContract
+```
+
+現在の `GNExceptionalValuationExcess p a b` は、`GN p a b` の factorization support のうち `q ∣ p` を満たす prime `q` に対し、
+
+$$\bigl(v_q(GN_p(a,b))-1\bigr)\log q$$
+
+を合計する。
+
+`p` が素数なら、例外 support は `q = p` の一箇所に潰れる。したがって M1 の核心は、`p` が GN に現れた場合の valuation が正確に一であることを示す点にある。
+
+## 3. Mathematical target
+
+`T : Triple`、`p : ℕ` とし、
+
+```text
+Nat.Prime p
+2 < p
+0 < T.a
+0 < T.b
+```
+
+を仮定する。
+
+攻略核は次の連鎖である。
+
+```text
+p ∣ GN p T.a T.b
+  -> p ∣ T.a
+  -> p ∤ T.b                  by T.hcop
+  -> ¬ p^2 ∣ GN p T.a T.b
+  -> padicValNat p (GN p T.a T.b) = 1
+  -> factorization multiplicity = 1
+  -> exceptional summand = 0
+  -> GNExceptionalValuationExcess p T.a T.b = 0
+```
+
+一般奇素数 proof では、次のいずれかを採用する。
+
+1. binomial expansion modulo `p^2`;
+2. LTE on `(T.a + T.b)^p - T.b^p`, followed by the exact GN product split;
+3. existing Mathlib / DkMath valuation lemmas capable of expressing the same local statement.
+
+実装では、最小依存・最小 theorem surface を優先する。
+
+## 4. Two-stage assault
+
+### Stage A: exponent five reconnaissance
+
+まず `p = 5` を固定し、既存の GN5 観測と同じ算術を一般 `GN` 座標上で再現する。
+
+目標:
+
+```lean
+Triple.GNExceptionalValuationExcess_five_eq_zero
+```
+
+この checkpoint は、一般化 API を先に設計しすぎず、exceptional support sum を実際にゼロへ落とせることを確認する。
+
+ただし production ABC module から `DkMath.FLT.Five.*` を import しない。必要な恒等式は一般 GN 側で証明するか、適切な NumberTheory / CosmicFormula 層へ置く。
+
+### Stage B: odd-prime exponent theorem
+
+Stage A の局所構造を奇素数 `p` へ一般化する。
+
+主目標:
+
+```lean
+Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+```
+
+続いて budget wrapper を供給する。
+
+```lean
+Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+```
+
+## 5. Planned implementation surface
+
+第一候補:
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+必要に応じて補助層を分離する。
+
+```text
+DkMath/NumberTheory/GN/OddPrimeExceptional.lean
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+配置原則:
+
+```text
+一般 GN の合同・valuation 定理
+  -> NumberTheory / CosmicFormulaBinom
+
+ABC Triple wrapper と budget bridge
+  -> DkMath.ABC
+```
+
+## 6. Completion criteria
+
+M1 完了条件は次のすべて。
+
+```text
+1. odd-prime exponent の exceptional support が singleton 以下へ潰れる
+2. support 上の exceptional valuation が exact 1 と証明される
+3. GNExceptionalValuationExcess = 0 が閉じる
+4. GNExceptionalExcessBudgetAffine T p 0 0 が得られる
+5. 既存 split budget に無損失で接続される
+6. focused build が通る
+7. representative endpoint の axiom audit に新規 project axiom がない
+```
+
+## 7. Scope boundary
+
+本プロジェクトは次を主張しない。
+
+```text
+ABC conjecture is proved
+M2 support-growth budget is solved
+M3 non-exceptional high-lift budget is solved
+GN is generally squarefree
+all composite exponents have zero exceptional excess
+all prime exponents including p = 2 are covered
+```
+
+また、次を行わない。
+
+```text
+no modification of abc_main_axiom
+no FLT7 dependency
+no unrelated refactor
+no new axiom
+no sorry
+no native_decide proof
+```
+
+## 8. Documents
+
+```text
+README.md
+ABC-GN-M1-IMPLEMENTATION-DESIGN.md
+ABC-GN-M1-ROADMAP.md
+```
+
+読む順序:
+
+```text
+README.md
+  -> ABC-GN-M1-IMPLEMENTATION-DESIGN.md
+  -> ABC-GN-M1-ROADMAP.md
+```
+
+## 9. Campaign doctrine
+
+M1 は三予算のうち、指数を奇素数へ固定することで局所算術へ圧縮できる魔核である。
+
+```text
+exceptional support width = at most one prime p
+exceptional multiplicity = exactly one copy
+exceptional excess = zero
+```
+
+ここを確実に閉じ、残る戦線を M2 と M3 の二体へ縮退させる。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/README.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/README.md
@@ -1,7 +1,7 @@
 # ABC–GN M1: Odd-Prime Exponent Exceptional Excess
 
 作成日: 2026-07-25  
-Status: **WIP / campaign initialized**
+Status: **M1-004 complete / M1-005 active / autonomous continuation enabled**
 
 Repository: `Deskuma/dkmath`  
 Base branch: `feature/ABC-GN-valuation-excess-260724-v0`  
@@ -19,17 +19,14 @@ M3  uniform non-exceptional valuation excess
 
 本プロジェクトの目標は、指数を奇素数 `p` に固定したとき、指数例外 prime channel の valuation excess が完全に消えることを Lean で証明することである。
 
-最終目標は、正の ABC triple `T` と奇素数 `p` に対して次を得ること。
-
-$$GNExceptionalValuationExcess\ p\ T.a\ T.b=0$$
-
-その結果、既存の exceptional affine budget を係数・定数ともにゼロで供給する。
+最終目標:
 
 ```lean
+GNExceptionalValuationExcess p T.a T.b = 0
 GNExceptionalExcessBudgetAffine T p 0 0
 ```
 
-すなわち、最終 budget contract の第一成分を
+すなわち、最終 budget contract の第一成分を:
 
 ```text
 τe = 0
@@ -38,9 +35,21 @@ De = 0
 
 へ固定する。
 
-## 2. Existing deterministic spine
+## 2. Current campaign state
 
-基底ブランチには、次の構造が既に実装されている。
+```text
+M1-000  campaign initialization                              complete
+M1-001  theorem/API reconnaissance                           complete / Outcome B
+M1-002  exponent-five divisibility and no-lift kernel        complete
+M1-003  exponent-five exceptional excess = 0                 complete / minimum victory
+M1-004  odd-prime general local valuation-one theorem        complete
+M1-005  odd-prime exceptional excess = 0 and budget bridge   active
+M1-006  integration, audit, documentation closure            follows autonomously
+```
+
+## 3. Existing deterministic spine
+
+基底ブランチには次が実装されている。
 
 ```text
 DkMath/ABC/GNExceptionalSplit.lean
@@ -60,120 +69,205 @@ DkMath/ABC/GNFinalBudgetBridge.lean
   ABCGNFinalBudgetContract
 ```
 
-現在の `GNExceptionalValuationExcess p a b` は、`GN p a b` の factorization support のうち `q ∣ p` を満たす prime `q` に対し、
+`GNExceptionalValuationExcess p a b` は、`GN p a b` の factorization support のうち `q ∣ p` を満たす prime `q` に対し、
 
 $$\bigl(v_q(GN_p(a,b))-1\bigr)\log q$$
 
 を合計する。
 
-`p` が素数なら、例外 support は `q = p` の一箇所に潰れる。したがって M1 の核心は、`p` が GN に現れた場合の valuation が正確に一であることを示す点にある。
+`p` が素数なら exceptional support は `q = p` の一箇所に潰れる。M1 の核心は、`p` が GN に現れた場合の valuation が正確に一であることを示す点にある。
 
-## 3. Mathematical target
+## 4. Fixed-five minimum victory
 
-`T : Triple`、`p : ℕ` とし、
-
-```text
-Nat.Prime p
-2 < p
-0 < T.a
-0 < T.b
-```
-
-を仮定する。
-
-攻略核は次の連鎖である。
+M1-002 は一般 `GN` の指数 `5` を明示展開し、
 
 ```text
-p ∣ GN p T.a T.b
-  -> p ∣ T.a
-  -> p ∤ T.b                  by T.hcop
-  -> ¬ p^2 ∣ GN p T.a T.b
-  -> padicValNat p (GN p T.a T.b) = 1
-  -> factorization multiplicity = 1
-  -> exceptional summand = 0
-  -> GNExceptionalValuationExcess p T.a T.b = 0
+5 ∣ GN 5 a b
+  -> 5 ∣ a
+  -> Coprime a b gives 25 ∤ GN 5 a b
+  -> padicValNat 5 (GN 5 a b) = 1
+  -> factorization 5 = 1
 ```
 
-一般奇素数 proof では、次のいずれかを採用する。
+を証明した。
 
-1. binomial expansion modulo `p^2`;
-2. LTE on `(T.a + T.b)^p - T.b^p`, followed by the exact GN product split;
-3. existing Mathlib / DkMath valuation lemmas capable of expressing the same local statement.
+M1-003 は finite exceptional support へ接続し、positivity 無しで:
 
-実装では、最小依存・最小 theorem surface を優先する。
+```lean
+Triple.GNExceptionalValuationExcess_five_eq_zero
+Triple.GNExceptionalExcessBudgetAffine_five_zero
+```
 
-## 4. Two-stage assault
+を完成した。
 
-### Stage A: exponent five reconnaissance
+したがって固定指数 `5` では:
 
-まず `p = 5` を固定し、既存の GN5 観測と同じ算術を一般 `GN` 座標上で再現する。
+```text
+τe = 0
+De = 0
+```
+
+が確定している。
+
+## 5. General odd-prime local victory
+
+M1-004 は canonical `GN` と geometric quotient の一般 bridge を証明した。
+
+```lean
+theorem GN_eq_geom_sum₂ (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i)
+```
+
+さらに prime-row boundary congruence から:
+
+```lean
+theorem prime_dvd_boundary_of_dvd_GN_prime
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpGN : p ∣ GN p a b) :
+    p ∣ a
+```
+
+を得た。
+
+奇素数 `p` と coprime 境界について、Mathlib の `emultiplicity_geom_sum₂_eq_one` を経由し:
+
+```lean
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
+
+ theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1
+```
+
+を完成した。
+
+この theorem も positivity を必要としない。
+
+## 6. Active M1-005
+
+一般奇素数の local factorization-one theorem を exceptional finite sum へ接続する。
 
 目標:
 
 ```lean
-Triple.GNExceptionalValuationExcess_five_eq_zero
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalValuationExcess p T.a T.b = 0
+
+ theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalExcessBudgetAffine T p 0 0
 ```
 
-この checkpoint は、一般化 API を先に設計しすぎず、exceptional support sum を実際にゼロへ落とせることを確認する。
+証明核:
 
-ただし production ABC module から `DkMath.FLT.Five.*` を import しない。必要な恒等式は一般 GN 側で証明するか、適切な NumberTheory / CosmicFormula 層へ置く。
-
-### Stage B: odd-prime exponent theorem
-
-Stage A の局所構造を奇素数 `p` へ一般化する。
-
-主目標:
-
-```lean
-Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+```text
+q in exceptional support
+  -> q.Prime
+  -> q ∣ p
+  -> q = p
+  -> support gives p ∣ GN
+  -> factorization p = 1
+  -> summand = 0
+  -> finite sum = 0
 ```
 
-続いて budget wrapper を供給する。
+## 7. Dual-Brain campaign doctrine
 
-```lean
-Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+Codex と Wise Wolf は、主従関係ではない。
+
+```text
+two peer reasoning agents
+two search paths
+one Lean kernel judge
 ```
 
-## 5. Planned implementation surface
+checkpoint は、後から相互監査するための観測点であり、次へ進む許可待ちの関所ではない。
 
-第一候補:
+checkpoint 完了後、Codex は次を自己判断する。
+
+```text
+結果の数学的意味
+新しく確定した Core
+残った Gap
+依存関係と theorem ownership
+次の最有力 route
+必要な micro-checkpoint
+```
+
+そして新しい指示を待たず、campaign 内の次 checkpoint へ進む。
+
+ただし、次は維持する。
+
+```text
+coherent theorem layer
+focused build
+checkpoint report
+reviewable change boundary
+```
+
+M1-005 完了後は M1-006 integration/audit へ連続進行し、M1 閉鎖後は M2/M3 の次戦線を調査・設計する。
+
+## 8. Planned implementation surface
+
+局所 arithmetic owner:
 
 ```text
 DkMath/ABC/GNOddPrimeExceptionalExcess.lean
 ```
 
-必要に応じて補助層を分離する。
+finite-sum / budget bridge candidate:
 
 ```text
-DkMath/NumberTheory/GN/OddPrimeExceptional.lean
-DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+DkMath/ABC/GNExceptionalExcessOddPrime.lean
 ```
 
 配置原則:
 
 ```text
-一般 GN の合同・valuation 定理
-  -> NumberTheory / CosmicFormulaBinom
+一般 GN の合同・geometric quotient・valuation 定理
+  -> NumberTheory / CosmicFormula owner も候補
 
 ABC Triple wrapper と budget bridge
   -> DkMath.ABC
 ```
 
-## 6. Completion criteria
+`GN_eq_geom_sum₂` と prime boundary theorem の最終 ownership は M1-006 で監査する。再利用・依存方向の利得が churn を上回る場合だけ移動する。
 
-M1 完了条件は次のすべて。
+## 9. Completion criteria
+
+M1 完了条件:
 
 ```text
-1. odd-prime exponent の exceptional support が singleton 以下へ潰れる
-2. support 上の exceptional valuation が exact 1 と証明される
-3. GNExceptionalValuationExcess = 0 が閉じる
-4. GNExceptionalExcessBudgetAffine T p 0 0 が得られる
-5. 既存 split budget に無損失で接続される
-6. focused build が通る
-7. representative endpoint の axiom audit に新規 project axiom がない
+1. odd-prime exceptional support が singleton 以下へ潰れる
+2. support 上の exceptional valuation が exact 1
+3. GNExceptionalValuationExcess = 0
+4. GNExceptionalExcessBudgetAffine T p 0 0
+5. split budget への無損失接続
+6. focused build
+7. representative endpoint axiom audit
+8. dependency and ownership audit
+9. FINAL_REPORT
 ```
 
-## 7. Scope boundary
+## 10. Scope and trust boundary
 
 本プロジェクトは次を主張しない。
 
@@ -183,44 +277,43 @@ M2 support-growth budget is solved
 M3 non-exceptional high-lift budget is solved
 GN is generally squarefree
 all composite exponents have zero exceptional excess
-all prime exponents including p = 2 are covered
+prime exponent p = 2 is covered
 ```
 
-また、次を行わない。
+絶対境界:
 
 ```text
 no modification of abc_main_axiom
-no FLT7 dependency
+no ABC -> FLT.Five production dependency
+no FLT7 WIP dependency
 no unrelated refactor
 no new axiom
 no sorry
 no native_decide proof
+no finite enumeration as general proof
 ```
 
-## 8. Documents
+これらは主従命令ではなく、Lean trust boundary と repository dependency boundary である。
+
+## 11. Documents
 
 ```text
 README.md
 ABC-GN-M1-IMPLEMENTATION-DESIGN.md
 ABC-GN-M1-ROADMAP.md
+CODEX_START.md
+report-M1-001.md
+report-M1-002.md
+review-M1-002.md
+report-M1-003.md
+review-M1-003.md
+report-M1-004.md
+review-M1-004.md
+instruction-M1-005.md
 ```
 
-読む順序:
+現在の入口は:
 
 ```text
-README.md
-  -> ABC-GN-M1-IMPLEMENTATION-DESIGN.md
-  -> ABC-GN-M1-ROADMAP.md
+CODEX_START.md
 ```
-
-## 9. Campaign doctrine
-
-M1 は三予算のうち、指数を奇素数へ固定することで局所算術へ圧縮できる魔核である。
-
-```text
-exceptional support width = at most one prime p
-exceptional multiplicity = exactly one copy
-exceptional excess = zero
-```
-
-ここを確実に閉じ、残る戦線を M2 と M3 の二体へ縮退させる。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-002.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-002.md
@@ -1,0 +1,240 @@
+# Codex Instruction M1-002
+
+## Mission
+
+Implement the fixed exponent-five local kernel for M1.
+
+Do not close the full exceptional finite sum in this checkpoint. The target is only the local arithmetic chain:
+
+```text
+5 ∣ GN 5 a b
+  -> 5 ∣ a
+  -> Coprime a b gives 5 ∤ b
+  -> 25 ∤ GN 5 a b
+  -> padicValNat 5 (GN 5 a b) = 1
+```
+
+## Branch
+
+```text
+wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
+```
+
+## Read first
+
+```text
+lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/README.md
+lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-IMPLEMENTATION-DESIGN.md
+lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/ABC-GN-M1-ROADMAP.md
+lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-001.md
+
+lean/dk_math/DkMath/ABC/GNValuationExcess.lean
+lean/dk_math/DkMath/ABC/PadicValNat.lean
+lean/dk_math/DkMath/CosmicFormula/CosmicFormulaBinom.lean
+```
+
+Read-only comparison only:
+
+```text
+lean/dk_math/DkMath/FLT/Five/GN5.lean
+```
+
+Do not import `DkMath.FLT.Five.*` into the new ABC module.
+
+## Create
+
+Preferred file:
+
+```text
+lean/dk_math/DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+Initial imports should be minimal. Prefer starting from:
+
+```lean
+import DkMath.ABC.GNValuationExcess
+```
+
+Add another import only when the used theorem requires it.
+
+## Required theorem surface
+
+Exact names may be adjusted for local naming conventions, but preserve this mathematical decomposition.
+
+### 1. Explicit general-GN specialization at exponent five
+
+```lean
+theorem GN_five_eq_explicit (a b : ℕ) :
+    GN 5 a b =
+      a ^ 4 + 5 * a ^ 3 * b + 10 * a ^ 2 * b ^ 2 +
+        10 * a * b ^ 3 + 5 * b ^ 4 := by
+  ...
+```
+
+Use canonical `GN_eq_sum` or unfold the canonical `GN`/`GTail` definition only as far as necessary. Do not duplicate the FLT5 `GN5` definition in production code.
+
+### 2. Divisibility detection
+
+```lean
+theorem five_dvd_boundary_of_dvd_GN_five
+    {a b : ℕ}
+    (h5GN : 5 ∣ GN 5 a b) :
+    5 ∣ a := by
+  ...
+```
+
+Recommended route:
+
+```text
+GN 5 a b = a^4 + 5*K
+5 ∣ GN -> 5 ∣ a^4
+Nat.Prime.dvd_of_dvd_pow prime_five -> 5 ∣ a
+```
+
+A small auxiliary decomposition theorem is acceptable:
+
+```lean
+GN 5 a b = a ^ 4 + 5 * K
+```
+
+### 3. No square lift under coprimality
+
+```lean
+theorem not_twentyFive_dvd_GN_five_of_coprime
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    ¬ 25 ∣ GN 5 a b := by
+  ...
+```
+
+Required arithmetic meaning:
+
+```text
+5 | a
+5 ∤ b
+GN 5 a b ≡ 5*b^4 mod 25
+5*b^4 is not divisible by 25
+```
+
+Choose the shortest stable Lean route:
+
+```text
+explicit quotient witnesses and omega/ring
+Nat.ModEq
+prime-power divisibility lemmas
+padicValNat upper-bound contradiction
+```
+
+Do not use brute-force finite enumeration.
+
+### 4. Exact p-adic valuation one
+
+```lean
+theorem padicValNat_five_GN_five_eq_one_of_dvd
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b)
+    (hGN0 : GN 5 a b ≠ 0) :
+    padicValNat 5 (GN 5 a b) = 1 := by
+  ...
+```
+
+Try to remove `hGN0` if it follows automatically from `h5GN` and the contradiction with zero / no-square-lift. The final theorem should have the weakest natural assumptions.
+
+Suggested proof:
+
+```text
+1 ≤ valuation from 5 | GN
+valuation < 2 from ¬ 5^2 | GN
+omega
+```
+
+Use existing:
+
+```lean
+padicValNat_one_le_of_prime_dvd
+padicValNat_le_iff_dvd
+```
+
+or direct Mathlib equivalents.
+
+### 5. Factorization wrapper
+
+If it is short and useful for M1-003, add:
+
+```lean
+theorem factorization_five_GN_five_eq_one_of_dvd
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    (GN 5 a b).factorization 5 = 1 := by
+  ...
+```
+
+Use:
+
+```lean
+Nat.factorization_def _ prime_five
+```
+
+Do not implement the filtered-sum theorem yet.
+
+## Scope restrictions
+
+Do not:
+
+```text
+prove GNExceptionalValuationExcess 5 ... = 0 yet
+change GNExceptionalValuationExcess definition
+change GNFinalBudgetBridge
+modify abc_main_axiom
+import FLT.Five into ABC
+start odd-prime generalization
+change aggregators unless required for the focused build
+add sorry, axiom, native_decide
+modify unrelated files
+```
+
+## Validation
+
+Run the narrowest build first.
+
+```text
+cd lean/dk_math
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+```
+
+If the module is not yet in an aggregator, build it by module name directly.
+
+Then run:
+
+```text
+git diff --check
+```
+
+## Report
+
+Create:
+
+```text
+lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-002.md
+```
+
+Report:
+
+```text
+exact theorem names
+proof route selected
+imports added
+build result
+whether hGN0 was necessary
+whether factorization wrapper was included
+remaining obstacle for M1-003
+```
+
+## Stop condition
+
+After the local valuation-one theorem and focused build pass, stop.
+
+Do not proceed automatically to M1-003. Commit and report the checkpoint for review.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-003.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-003.md
@@ -1,0 +1,207 @@
+# Codex Instruction M1-003
+
+## Mission
+
+Close the exponent-five exceptional finite sum and expose the exact zero affine budget.
+
+M1-002 is complete at commit:
+
+```text
+3fa7baceb34f7b184168e68fb16b9d76bf4d122b
+```
+
+Review:
+
+```text
+review-M1-002.md
+```
+
+This checkpoint must use the local factorization-one theorem already proved in:
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+Do not reprove the modulo-5 or modulo-25 arithmetic.
+
+## Branch
+
+```text
+wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
+```
+
+## Preferred new module
+
+Create:
+
+```text
+lean/dk_math/DkMath/ABC/GNExceptionalExcessFive.lean
+```
+
+Preferred imports:
+
+```lean
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+```
+
+Reason: preserve `GNOddPrimeExceptionalExcess.lean` as the low-dependency local arithmetic kernel. The new file is the thin finite-sum / final-budget connection layer.
+
+## Required theorem 1
+
+Prefer the strongest theorem without unnecessary positivity assumptions:
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_five_eq_zero
+    (T : Triple) :
+    GNExceptionalValuationExcess 5 T.a T.b = 0
+```
+
+Do not add `0 < T.a` or `0 < T.b` unless Lean forces them. Current local theorem requires only `T.hcop` and divisibility of the GN kernel.
+
+## Finite-sum proof route
+
+Unfold only the exceptional finite sum.
+
+```text
+GNExceptionalValuationExcess 5 T.a T.b
+  = sum over
+      (GN 5 T.a T.b).factorization.support.filter (fun q => q ∣ 5)
+```
+
+For each `q` in the filtered support:
+
+```text
+1. split Finset.mem_filter into:
+     hqSupport : q ∈ factorization.support
+     hqDvdFive : q ∣ 5
+
+2. derive q.Prime canonically from factorization support:
+     convert support membership to primeFactors membership using
+     Nat.support_factorization
+     then use Nat.prime_of_mem_primeFactors
+
+3. derive q = 5:
+     q ∣ 5 and prime q
+     exclude q = 1
+
+4. substitute q = 5
+
+5. derive 5 ∣ GN 5 T.a T.b from hqSupport:
+     Finsupp.mem_support_iff.mp hqSupport gives nonzero factorization
+     Nat.dvd_of_factorization_pos is the preferred bridge if its signature fits
+
+6. use:
+     factorization_five_GN_five_eq_one_of_dvd T.hcop h5GN
+
+7. simplify:
+     ((1 - 1 : ℕ) : ℝ) * Real.log (5 : ℝ) = 0
+```
+
+Preferred outer pattern:
+
+```lean
+classical
+unfold GNExceptionalValuationExcess
+apply Finset.sum_eq_zero
+intro q hq
+...
+```
+
+Use canonical existing lemmas. Do not introduce a custom support structure or enumerate the filtered set manually.
+
+## Required theorem 2
+
+Expose the exact zero budget:
+
+```lean
+theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
+    (T : Triple) :
+    GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+This should be a thin consequence of theorem 1.
+
+Expected shape:
+
+```text
+unfold GNExceptionalExcessBudgetAffine
+rw [T.GNExceptionalValuationExcess_five_eq_zero]
+simp
+```
+
+Exact syntax may vary.
+
+## Optional theorem
+
+Only if it materially simplifies theorem 1, a tiny support-collapse lemma is allowed:
+
+```lean
+q ∈ (GN 5 a b).factorization.support.filter (fun q => q ∣ 5) → q = 5
+```
+
+Do not build a larger singleton-set API unless needed.
+
+## Validation
+
+Run focused builds for the new module.
+
+```text
+lake build DkMath.ABC.GNExceptionalExcessFive
+```
+
+Audit the two endpoint theorems with `#print axioms` from a temporary audit module or existing audit workflow.
+
+Report:
+
+```text
+report-M1-003.md
+```
+
+The report must record:
+
+```text
+exact theorem statements
+whether positivity assumptions were avoided
+canonical support -> prime -> q=5 route
+support -> 5 ∣ GN route
+zero-budget wrapper
+focused build result
+axiom audit result
+```
+
+## Stop boundary
+
+Stop after:
+
+```text
+GNExceptionalValuationExcess 5 T.a T.b = 0
+GNExceptionalExcessBudgetAffine T 5 0 0
+focused build
+report-M1-003.md
+commit
+```
+
+Do not automatically begin:
+
+```text
+M1-004 odd-prime generalization
+M1-005 general odd-prime sum closure
+M2 support-growth work
+M3 non-exceptional excess work
+aggregator/public import changes
+```
+
+The checkpoint review will decide whether to seal the fixed-five minimum victory or continue immediately to M1-004.
+
+## Forbidden scope
+
+```text
+no abc_main_axiom modification
+no ABC -> FLT.Five import
+no FLT7 work
+no unrelated refactor
+no sorry
+no axiom
+no native_decide
+```

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-004.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-004.md
@@ -1,0 +1,355 @@
+# Codex Instruction M1-004: odd-prime local exceptional valuation-one theorem
+
+## 0. Objective
+
+Generalize the completed exponent-five local kernel to an arbitrary odd prime exponent.
+
+Implement only the local theorem:
+
+```lean
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
+```
+
+An equivalent theorem using `2 < p` instead of `Odd p` is acceptable if it fits the available API better.
+
+Also expose the direct factorization wrapper:
+
+```lean
+theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1
+```
+
+Do not close the exceptional filtered sum in this checkpoint. That belongs to M1-005.
+
+## 1. Current completed base
+
+M1-002 established the exponent-five local theorem in:
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+M1-003 established the fixed-five finite-sum and exact-zero budget in:
+
+```text
+DkMath/ABC/GNExceptionalExcessFive.lean
+```
+
+Reviewed commits:
+
+```text
+3fa7baceb34f7b184168e68fb16b9d76bf4d122b
+8a9690b41be321fed2b15dc9d578512388322a0d
+```
+
+M1-003 is fully accepted. The fixed-five minimum victory is complete:
+
+```text
+GNExceptionalValuationExcess 5 T.a T.b = 0
+GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+## 2. Required mathematical chain
+
+For an odd prime `p`, coprime `a,b`, and `p ∣ GN p a b`, establish:
+
+```text
+p ∣ GN p a b
+  -> p ∣ a
+  -> p ∤ b
+  -> p ∤ a + b
+  -> the p-multiplicity of the geometric quotient is exactly one
+  -> padicValNat p (GN p a b) = 1
+```
+
+The first implication should be exposed as a reusable local theorem if practical:
+
+```lean
+theorem prime_dvd_boundary_of_dvd_GN_prime
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpGN : p ∣ GN p a b) :
+    p ∣ a
+```
+
+No positivity assumptions on `a` or `b` should be introduced unless Lean genuinely requires them. The case `a = 0` is mathematically valid and should not be discarded without reason.
+
+## 3. Primary proof route
+
+Use the exact Mathlib theorem:
+
+```lean
+emultiplicity_geom_sum₂_eq_one
+```
+
+from:
+
+```text
+Mathlib/NumberTheory/Multiplicity.lean
+```
+
+Its conceptual specialization is:
+
+```text
+R = ℤ
+x = a + b
+y = b
+x - y = a
+```
+
+The theorem requires:
+
+```text
+Prime (p : ℤ)
+Odd p
+(p : ℤ) ∣ x - y
+¬ (p : ℤ) ∣ x
+```
+
+The intended input construction is:
+
+```text
+p ∣ a
+Coprime a b -> p ∤ b
+p ∣ a and p ∤ b -> p ∤ a+b
+```
+
+Then the geometric quotient
+
+```lean
+∑ i ∈ Finset.range p,
+  (a + b) ^ i * b ^ (p - 1 - i)
+```
+
+has exact `p`-multiplicity one.
+
+## 4. GN / geometric-sum bridge
+
+A bridge is required between canonical `GN` and the geometric quotient.
+
+Preferred statement:
+
+```lean
+theorem GN_eq_geom_sum₂
+    (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i)
+```
+
+Equivalent orientation or an integer-cast form is acceptable.
+
+Do not prove this identity by expanding a fixed exponent. It must be general in `p`.
+
+Recommended routes, in order:
+
+```text
+A. existing `geom_sum₂_mul` plus the canonical GN power-gap identity
+B. cast the product identities to ℤ and cancel the boundary factor
+C. prove a short recurrence shared by GN and the geometric sum
+D. direct finite-sum reindexing only if the previous routes are genuinely worse
+```
+
+If cancellation requires `a ≠ 0`, split the `a = 0` case explicitly rather than adding positivity to the public theorem.
+
+Ownership rule:
+
+```text
+Keep the bridge in GNOddPrimeExceptionalExcess.lean for this checkpoint
+unless it is clearly import-neutral and immediately reusable.
+```
+
+Do not create a large new abstraction tower merely to relocate one identity.
+
+## 5. Boundary divisibility `p ∣ GN -> p ∣ a`
+
+Prove the general prime-exponent congruence needed to derive the boundary divisibility.
+
+Acceptable forms include:
+
+```lean
+GN p a b % p = a ^ (p - 1) % p
+```
+
+or directly:
+
+```lean
+p ∣ GN p a b -> p ∣ a
+```
+
+Possible routes:
+
+```text
+A. prime divisibility of intermediate binomial coefficients in GN_eq_sum
+B. prime-power freshman-dream congruence applied to
+   a * GN p a b + b^p = (a+b)^p
+C. an existing Mathlib theorem giving the same congruence
+```
+
+Prefer the shortest kernel-stable route. Do not use finite enumeration.
+
+## 6. Multiplicity transfer
+
+After obtaining exact geometric-sum multiplicity one, transfer it to:
+
+```text
+padicValNat p (GN p a b) = 1
+```
+
+and then to:
+
+```text
+(GN p a b).factorization p = 1
+```
+
+Useful existing bridge:
+
+```lean
+Nat.factorization_def
+```
+
+Inspect the exact current signatures before committing. Avoid introducing a new general multiplicity framework if the existing `emultiplicity` / `padicValNat` bridge is sufficient.
+
+## 7. Alternative route if the primary bridge becomes costly
+
+A local LTE route is acceptable:
+
+```text
+(a+b)^p - b^p = a * GN p a b
+```
+
+combine:
+
+```lean
+Nat.emultiplicity_pow_sub_pow
+```
+
+with the exact multiplicity of `p` in the exponent `p`, and compare the product multiplicity with the boundary-plus-GN split.
+
+Use this route only if it gives a smaller proof surface than `GN_eq_geom_sum₂` plus `emultiplicity_geom_sum₂_eq_one`.
+
+The endpoint must remain the same.
+
+## 8. Outcome branches
+
+### Outcome A: direct general theorem closes
+
+Deliver:
+
+```text
+prime boundary divisibility
+GN/geometric-sum bridge or equivalent
+padicValNat exact one
+factorization exact one
+```
+
+Then stop and report success.
+
+### Outcome B: multiplicity theorem applies, but one transfer bridge is missing
+
+Implement the strongest completed neutral bridge and report the exact remaining type mismatch.
+
+Do not replace it with an axiom or a stronger assumption.
+
+### Outcome C: `GN = geom_sum₂` is unexpectedly costly
+
+Try the LTE/product-split route before proposing a foundational refactor.
+
+Record the obstruction precisely, including exact goal and theorem signatures.
+
+## 9. Preferred file scope
+
+First preference:
+
+```text
+modify:
+  DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+A small neutral helper module is allowed only if dependency ownership clearly improves:
+
+```text
+DkMath/NumberTheory/GN/OddPrimeExceptional.lean
+```
+
+If a neutral helper is created, the ABC module should contain only thin wrappers.
+
+Do not modify:
+
+```text
+DkMath/ABC/GNExceptionalExcessFive.lean
+DkMath/ABC/GNFinalBudgetBridge.lean
+abc_main_axiom or legacy ABC prototype axioms
+FLT5 or FLT7 modules
+aggregators
+```
+
+## 10. Validation
+
+Run a focused build for every changed/new module.
+
+Minimum required build:
+
+```text
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+```
+
+If a neutral helper module is added, build it separately first.
+
+Audit the final local endpoints with `#print axioms` from a temporary audit file.
+
+Forbidden:
+
+```text
+sorry
+new axiom
+native_decide
+finite enumeration as proof
+```
+
+## 11. Report
+
+Create:
+
+```text
+report-M1-004.md
+```
+
+The report must state:
+
+```text
+selected proof route
+exact Mathlib theorem signatures used
+GN/geometric-sum or LTE bridge obtained
+how p ∣ GN implies p ∣ a
+how coprimality gives p ∤ a+b
+how emultiplicity is transferred to padicValNat
+public theorem surface
+focused build result
+axiom audit result
+```
+
+## 12. Stop boundary
+
+M1-004 ends after the general local factorization-one theorem, focused build, report, and commit.
+
+Do not automatically start:
+
+```text
+M1-005 odd-prime exceptional finite-sum closure
+M1-006 integration/audit closure
+M2 support-growth work
+M3 non-exceptional valuation work
+aggregator changes
+```

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-005.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/instruction-M1-005.md
@@ -1,0 +1,303 @@
+# M1-005 Instruction: Odd-prime exceptional excess closure and autonomous M1 completion
+
+Date: 2026-07-26
+
+## 0. Operating doctrine
+
+This is not a stop-bounded subordinate task.
+
+Codex and Wise Wolf are peer reasoning agents operating as two brains over the same Lean-verified research program. Checkpoints are audit markers, not permission gates.
+
+After completing a checkpoint, do not wait for a new instruction. Evaluate the new repository state, choose the mathematically strongest next action consistent with the campaign and dependency boundaries, and continue.
+
+Preserve reviewability:
+
+```text
+one coherent theorem layer
+focused verification
+checkpoint report
+explicit statement of what changed mathematically
+then continue
+```
+
+Implementation, local verification, and reports are in scope. Repository publication operations remain user-controlled unless separately requested.
+
+## 1. Current facts
+
+M1-004 established, for every odd prime `p`:
+
+```lean
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
+
+ theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1
+```
+
+The proof is positivity-free and uses:
+
+```text
+prime-row GN boundary congruence
+GN = geometric quotient
+emultiplicity_geom_sum₂_eq_one
+padicValNat / factorization transfer
+```
+
+## 2. Primary M1-005 objective
+
+Close the odd-prime exceptional filtered sum and exact affine zero budget.
+
+Preferred new bridge module:
+
+```text
+lean/dk_math/DkMath/ABC/GNExceptionalExcessOddPrime.lean
+```
+
+A different placement is acceptable if repository inspection shows a cleaner existing owner. Keep the local arithmetic module and the finite-sum/final-budget bridge conceptually separated.
+
+Expected imports:
+
+```lean
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+```
+
+## 3. Required mathematical endpoints
+
+Target theorem shape:
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalValuationExcess p T.a T.b = 0
+```
+
+and:
+
+```lean
+theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalExcessBudgetAffine T p 0 0
+```
+
+Do not add positivity hypotheses unless actual Lean evidence forces them. Current mathematics indicates they are unnecessary.
+
+Exact names may improve after implementation. Preserve discoverability around:
+
+```text
+GNExceptionalValuationExcess
+oddPrime
+eq_zero
+zero budget
+```
+
+## 4. Finite-sum proof spine
+
+Unfold only the exceptional sum.
+
+For each summand index `q` in:
+
+```text
+(GN p T.a T.b).factorization.support.filter (fun q => q ∣ p)
+```
+
+extract:
+
+```text
+hqSupport : q ∈ (GN p T.a T.b).factorization.support
+hqDvdP    : q ∣ p
+```
+
+Then:
+
+```text
+hqSupport
+  -> q ∈ primeFactors
+  -> q.Prime
+
+q.Prime + q ∣ p + p.Prime
+  -> q = p
+```
+
+After substitution:
+
+```text
+hqSupport
+  -> (GN p T.a T.b).factorization p ≠ 0
+  -> p ∣ GN p T.a T.b
+```
+
+Use:
+
+```lean
+factorization_GN_prime_eq_one_of_dvd hp hpOdd T.hcop hpGN
+```
+
+and reduce the summand:
+
+```text
+(((1 - 1 : ℕ) : ℝ) * Real.log (p : ℝ)) = 0
+```
+
+The finite sum closes with `Finset.sum_eq_zero`.
+
+## 5. Exact budget and split-budget simplification
+
+The zero-budget theorem should be a thin wrapper around the finite-sum theorem.
+
+Also inspect whether the following caller-facing theorem materially improves the final contract surface:
+
+```lean
+theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
+    (T : Triple) {p : ℕ} {τn Dn : ℝ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
+    GNValuationExcessBudgetAffine T p τn Dn
+```
+
+It should be a thin application of:
+
+```lean
+GNValuationExcessBudgetAffine.of_split
+```
+
+using exceptional budget `(0,0)` and the supplied non-exceptional budget. Do not duplicate the final bridge proof.
+
+Treat this wrapper as a judgment call: include it if it gives a natural production-facing simplification; omit it if it creates an awkward theorem surface.
+
+## 6. Verification and report
+
+Verify the new bridge module and immediate dependents.
+
+At minimum:
+
+```text
+lake build DkMath.ABC.GNExceptionalExcessOddPrime
+lake build DkMath.ABC.GNFinalBudgetBridge
+```
+
+If the module name differs, adapt the focused build.
+
+Audit representative endpoints with `#print axioms` and record:
+
+```text
+new project axioms
+sorry
+native_decide
+```
+
+The expected result is none.
+
+Create:
+
+```text
+report-M1-005.md
+```
+
+The report must explain:
+
+```text
+support prime q collapses to exponent p
+support membership supplies p ∣ GN
+M1-004 supplies factorization p = 1
+all exceptional summands vanish
+τe = 0 and De = 0
+positivity status
+contract simplification
+```
+
+## 7. Autonomous continuation into M1-006
+
+After M1-005 closes, continue directly into M1-006 without waiting for review permission.
+
+M1-006 is an integration and ownership audit, not a new deep arithmetic proof.
+
+Evaluate and act on:
+
+```text
+1. public/aggregator import placement
+2. focused regression builds
+3. theorem statement and naming audit
+4. axiom audit
+5. dependency-direction audit
+6. fixed-five and odd-prime theorem coexistence
+7. ownership of neutral API:
+     GN_eq_geom_sum₂
+     prime_dvd_boundary_of_dvd_GN_prime
+8. README / roadmap / final report closure
+```
+
+For neutral API ownership, choose based on evidence:
+
+```text
+keep in ABC
+or
+move to NumberTheory / CosmicFormula and leave ABC thin
+```
+
+Do not refactor merely for aesthetic purity. Move only if reuse, dependency clarity, and theorem ownership clearly improve enough to justify churn.
+
+Create the final M1 closure report, expected path:
+
+```text
+FINAL_REPORT.md
+```
+
+The final report should state the exact theorem chain and the resulting contract reduction:
+
+```text
+odd-prime exceptional excess = 0
+τe = 0
+De = 0
+remaining final-contract enemies:
+  M2 lifted-radical support growth
+  M3 non-exceptional valuation excess
+```
+
+## 8. After M1 victory
+
+After M1 integration is complete, inspect the remaining repository state and choose the next strongest research action rather than idling at the milestone.
+
+Preserve branch hygiene:
+
+```text
+M1 changes remain in the M1 branch
+M2/M3 implementation belongs to its own campaign branch
+neutral prerequisite lemmas may be factored only when dependency ownership is clear
+```
+
+Continue with read-only reconnaissance and a concrete next-campaign design if the next implementation belongs on a new branch. If an immediately necessary neutral lemma is a direct consequence of the completed M1 chain and belongs in the current dependency graph, implementing it is acceptable when the report explains why.
+
+The objective is continuous mathematical progress with auditable boundaries, not permission-driven pauses.
+
+## 9. Hard trust and scope boundaries
+
+The following remain absolute:
+
+```text
+no abc_main_axiom modification
+no ABC -> FLT.Five production dependency
+no FLT7 WIP import
+no new axiom
+no sorry
+no native_decide proof
+no finite enumeration as a general proof
+no unrelated repository refactor
+```
+
+These are trust and dependency boundaries, not master-subordinate stop commands.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-001.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-001.md
@@ -1,0 +1,279 @@
+# M1-001 Report: Theorem and API Reconnaissance
+
+Date: 2026-07-25  
+Outcome: **B — fixed exponent five is immediate; odd-prime generalization needs one bridge layer**
+
+## 1. Decision
+
+The campaign will proceed in this order:
+
+```text
+M1-002  exponent-five local divisibility / no-lift theorem
+M1-003  exponent-five exceptional excess = 0
+M1-004  GN-to-geometric-sum bridge and odd-prime generalization
+M1-005  odd-prime exceptional excess = 0 and zero budget
+```
+
+The general odd-prime theorem remains credible and has a strong Mathlib endpoint, but it should not block the exact exponent-five victory.
+
+## 2. Existing DkMath findings
+
+### 2.1. GN owner and explicit sum
+
+`GN` is the `r = 1` specialization of canonical `GTail` and is exposed in:
+
+```text
+DkMath/CosmicFormula/CosmicFormulaBinom.lean
+```
+
+Relevant declarations:
+
+```lean
+DkMath.CosmicFormulaBinom.GN
+DkMath.CosmicFormulaBinom.GN_eq_sum
+DkMath.CosmicFormulaBinom.cosmic_id_csr'
+DkMath.CosmicFormulaBinom.add_pow_gap_factor
+```
+
+The explicit sum is:
+
+$$GN_d(x,u)=\sum_{k<d}\binom d{k+1}x^ku^{d-1-k}$$
+
+Therefore `d = 5` can be expanded locally without importing the FLT5 tower.
+
+### 2.2. ABC power-difference split
+
+Existing:
+
+```lean
+Triple.powerDiff_eq_boundary_mul_GN
+Triple.padic_powerDiff_eq_boundary_add_GN
+```
+
+The exact factorization is already available:
+
+$$T.c^n-T.b^n=T.a\,GN_n(T.a,T.b)$$
+
+No new ABC lift definition is required.
+
+### 2.3. Exceptional support definition
+
+Existing:
+
+```lean
+GNExceptionalValuationExcess
+```
+
+It is exactly a filtered sum over:
+
+```text
+q ∈ factorization.support (GN n a b)
+q ∣ n
+```
+
+For `n = 5`, every such support prime is `q = 5`.
+
+### 2.4. Factorization and padicValNat bridge
+
+Mathlib defines:
+
+```lean
+Nat.factorization n p :=
+  if p.Prime then padicValNat p n else 0
+```
+
+and exposes:
+
+```lean
+Nat.factorization_def
+```
+
+Thus, for prime `p`, a theorem
+
+```lean
+padicValNat p m = 1
+```
+
+rewrites directly to:
+
+```lean
+m.factorization p = 1
+```
+
+No new foundational equality theorem is required.
+
+Useful existing DkMath wrappers:
+
+```lean
+padicValNat_eq_zero_iff
+Vp_ge_one_iff
+padicValNat_one_le_of_prime_dvd
+padicValNat_le_iff_dvd
+```
+
+## 3. Exponent-five route
+
+The `GN_eq_sum` specialization gives:
+
+$$GN_5(a,b)=a^4+5a^3b+10a^2b^2+10ab^3+5b^4$$
+
+This yields two local congruences.
+
+### Modulo five
+
+$$GN_5(a,b)\equiv a^4\pmod5$$
+
+Therefore:
+
+$$5\mid GN_5(a,b)\Longrightarrow5\mid a$$
+
+### Modulo twenty-five
+
+If `5 ∣ a`, the first four terms are divisible by `25`, hence:
+
+$$GN_5(a,b)\equiv5b^4\pmod{25}$$
+
+If `Coprime a b`, then `5 ∤ b`, so:
+
+$$25\nmid GN_5(a,b)$$
+
+Combined with `5 ∣ GN₅`, this gives:
+
+$$v_5(GN_5(a,b))=1$$
+
+This route is finite, elementary, and independent of FLT5 final theorems.
+
+## 4. General odd-prime route
+
+Mathlib provides a highly relevant theorem in:
+
+```text
+Mathlib/NumberTheory/Multiplicity.lean
+```
+
+Core declaration:
+
+```lean
+emultiplicity_geom_sum₂_eq_one
+```
+
+Conceptually, for odd prime `p`, if
+
+```text
+p ∣ x - y
+p ∤ x
+```
+
+then the geometric quotient
+
+$$\sum_{i<p}x^iy^{p-1-i}$$
+
+has exact `p`-multiplicity one.
+
+The same file also exposes odd-prime LTE variants:
+
+```lean
+Int.emultiplicity_pow_sub_pow
+Nat.emultiplicity_pow_sub_pow
+```
+
+For ABC coordinates choose:
+
+```text
+x = T.a + T.b = T.c
+y = T.b
+x - y = T.a
+```
+
+The remaining bridge obligations are:
+
+```text
+A. identify GN p T.a T.b with the geometric quotient
+B. transfer emultiplicity = 1 to padicValNat / factorization = 1
+C. manage Nat subtraction or use an Int cast cleanly
+```
+
+These are local and plausible, but not needed for the fixed-five checkpoint.
+
+## 5. Selected implementation ownership
+
+Initial module:
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+The first checkpoint will contain exponent-five local facts only.
+
+If the general `GN = geom_sum₂` theorem is useful beyond ABC, M1-004 may move that bridge into a neutral owner such as:
+
+```text
+DkMath/NumberTheory/GN/OddPrimeExceptional.lean
+```
+
+No production dependency from `DkMath.ABC` to `DkMath.FLT.Five` will be introduced.
+
+## 6. M1-002 theorem surface
+
+Recommended local theorem chain:
+
+```lean
+GN_five_eq_explicit
+five_dvd_boundary_of_dvd_GN_five
+not_twentyFive_dvd_GN_five_of_coprime
+padicValNat_five_GN_five_eq_one_of_dvd
+factorization_five_GN_five_eq_one_of_mem_support
+```
+
+M1-002 stops after the local multiplicity-one theorem and focused build.
+
+M1-003 alone will unfold and close `GNExceptionalValuationExcess`.
+
+## 7. Rejected routes
+
+### Import FLT5 GN5 implementation into ABC
+
+Rejected because it reverses the desired dependency direction.
+
+```text
+ABC -> FLT.Five
+```
+
+would make a general ABC arithmetic layer depend on a problem-specific proof tower.
+
+### Start with full odd-prime LTE composition
+
+Deferred, not rejected. The mathematical endpoint exists, but the bridge overhead is larger than the complete exponent-five proof.
+
+### Prove general squarefreeness
+
+Rejected. M1 only needs the unique exponent-exceptional channel to have multiplicity one. It says nothing about non-exceptional repeated primes.
+
+## 8. Confidence assessment
+
+```text
+M1-002 fixed-five local kernel        high confidence
+M1-003 fixed-five excess zero         high confidence
+M1-004 odd-prime generalization       medium-high confidence
+M1-005 general zero budget            high after M1-004
+```
+
+## 9. Next checkpoint
+
+Proceed with:
+
+```text
+instruction-M1-002.md
+```
+
+The next implementation must remain small:
+
+```text
+one new module
+fixed exponent five only
+local divisibility / no-lift / valuation-one
+focused build
+report
+```
+
+Do not close the exceptional finite sum until M1-003.

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-002.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-002.md
@@ -1,0 +1,156 @@
+# M1-002 Report: 指数 5 の例外 valuation-one kernel
+
+Date: 2026-07-26  
+Outcome: **完了 — coprime 境界上で `5 ∣ GN 5 a b` なら 5 進付値はちょうど 1**
+
+## 1. 実装ファイル
+
+新規モジュール:
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+追加 import は次の 1 本だけである。
+
+```lean
+import DkMath.ABC.GNValuationExcess
+```
+
+`DkMath.FLT.Five.*` は import していない。集約モジュールも変更していない。
+
+## 2. 公開 theorem surface
+
+実装した定理は次のとおり。
+
+```lean
+DkMath.ABC.GN_five_eq_explicit
+DkMath.ABC.GN_five_eq_boundary_add_five_mul
+DkMath.ABC.five_dvd_boundary_of_dvd_GN_five
+DkMath.ABC.GN_five_five_mul_eq_twentyFive_mul_add
+DkMath.ABC.not_twentyFive_dvd_GN_five_of_coprime
+DkMath.ABC.padicValNat_five_GN_five_eq_one_of_dvd
+DkMath.ABC.factorization_five_GN_five_eq_one_of_dvd
+```
+
+主結果は次の自然な最小仮定で公開した。
+
+```lean
+theorem padicValNat_five_GN_five_eq_one_of_dvd
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    padicValNat 5 (GN 5 a b) = 1
+```
+
+factorization wrapper も追加した。
+
+```lean
+theorem factorization_five_GN_five_eq_one_of_dvd
+    {a b : ℕ}
+    (hcop : Nat.Coprime a b)
+    (h5GN : 5 ∣ GN 5 a b) :
+    (GN 5 a b).factorization 5 = 1
+```
+
+## 3. 採用した証明経路
+
+`GN_eq_sum` を指数 5 で有限展開し、`norm_num` と `ring` で canonical
+`GN` から直接次を得た。
+
+$$
+GN_5(a,b)=a^4+5a^3b+10a^2b^2+10ab^3+5b^4.
+$$
+
+これを
+
+$$
+GN_5(a,b)=a^4+5K
+$$
+
+と再配置した。したがって `5 ∣ GN₅(a,b)` なら `5 ∣ a⁴` であり、
+`Nat.Prime.dvd_of_dvd_pow` により `5 ∣ a` を得る。
+
+次に `a = 5k` を代入し、
+
+$$
+GN_5(5k,b)=25L+5b^4
+$$
+
+という明示的 witness 分解を `ring` で証明した。仮に `25 ∣ GN₅(5k,b)`
+なら `omega` により `5 ∣ b⁴`、従って `5 ∣ b` となる。しかし
+`Coprime (5k) b` から `Coprime 5 b` が従うため矛盾する。
+
+最後に既存 API
+
+```lean
+padicValNat_one_le_of_prime_dvd
+padicValNat_le_iff_dvd
+```
+
+を用いて
+
+```text
+1 ≤ padicValNat 5 (GN 5 a b)
+padicValNat 5 (GN 5 a b) < 2
+```
+
+を結合し、正確な付値 1 を得た。
+
+## 4. `hGN0` の扱い
+
+`hGN0 : GN 5 a b ≠ 0` は公開定理の仮定として不要だった。
+
+`GN 5 a b = 0` なら自動的に `25 ∣ GN 5 a b` であり、先に証明した
+no-square-lift と矛盾する。したがって非零性は theorem 内で導出している。
+
+## 5. 検証
+
+実行:
+
+```text
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+```
+
+結果:
+
+```text
+Build completed successfully (8321 jobs).
+```
+
+一時監査モジュールから全 7 定理に `#print axioms` を実行した。依存は
+Lean / Mathlib の標準的な
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+のみであり、独自 axiom はない。実装には `sorry`、`axiom`、
+`native_decide` を追加していない。
+
+## 6. M1-003 に残る課題
+
+局所因子 `q = 5` の valuation-one / factorization-one は閉じた。
+M1-003 の残作業は、指数 5 の例外 support にある素数について
+
+```text
+q ∣ 5 かつ q.Prime から q = 5
+```
+
+を示し、各 summand の
+
+```text
+(factorization q - 1 : ℕ)
+```
+
+を 0 に簡約して
+
+```lean
+GNExceptionalValuationExcess 5 a b = 0
+```
+
+を有限和レベルで閉じることだけである。この checkpoint では指示どおり
+filtered-sum theorem には進んでいない。
+

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-003.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-003.md
@@ -1,0 +1,169 @@
+# M1-003 Report: 指数 5 の exceptional excess 完全消去
+
+Date: 2026-07-26  
+Outcome: **完了 — exceptional finite sum と affine budget をともに厳密な 0 へ閉じた**
+
+## 1. 実装ファイル
+
+新規モジュール:
+
+```text
+DkMath/ABC/GNExceptionalExcessFive.lean
+```
+
+import:
+
+```lean
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+```
+
+M1-002 の低依存な局所算術 kernel は変更せず、新規ファイルを
+finite-sum / final-budget 接続層とした。FLT5 import と集約モジュール変更は
+ない。
+
+## 2. 完成した endpoint
+
+### Exceptional finite sum
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_five_eq_zero
+    (T : Triple) :
+    GNExceptionalValuationExcess 5 T.a T.b = 0
+```
+
+### Exact zero affine budget
+
+```lean
+theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
+    (T : Triple) :
+    GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+両 theorem とも `0 < T.a`、`0 < T.b` その他の positivity 仮定を必要と
+しない。
+
+## 3. Finite-sum の証明経路
+
+`GNExceptionalValuationExcess` だけを unfold し、filtered support 上の各
+`q` の summand が 0 であることを示した。
+
+```text
+q ∈ factorization.support.filter (fun q => q ∣ 5)
+  -> q ∈ factorization.support
+  -> q ∈ primeFactors
+  -> q.Prime
+  -> q ∣ 5
+  -> q = 5
+```
+
+support から prime への変換には canonical API:
+
+```lean
+Nat.support_factorization
+Nat.prime_of_mem_primeFactors
+```
+
+を用いた。`q = 5` には:
+
+```lean
+Nat.prime_dvd_prime_iff_eq
+```
+
+を用いたため、`q = 1` の分岐を手動で処理する必要はない。
+
+## 4. Support から GN divisibility への接続
+
+`q = 5` を代入した後、factorization support membership から:
+
+```lean
+Finsupp.mem_support_iff.mp hqSupport :
+  (GN 5 T.a T.b).factorization 5 ≠ 0
+```
+
+を得て、canonical bridge:
+
+```lean
+Nat.dvd_of_factorization_pos
+```
+
+により:
+
+```lean
+5 ∣ GN 5 T.a T.b
+```
+
+へ接続した。
+
+続いて M1-002 の既存 theorem:
+
+```lean
+factorization_five_GN_five_eq_one_of_dvd T.hcop h5GN
+```
+
+で multiplicity を 1 に書き換えた。その結果、
+
+```text
+((1 - 1 : ℕ) : ℝ) * Real.log (5 : ℝ) = 0
+```
+
+となり、各 summand と有限和全体が `simp` で 0 へ閉じた。modulo 5 /
+modulo 25 算術は再証明していない。
+
+## 5. Zero-budget wrapper
+
+`GNExceptionalExcessBudgetAffine` を unfold し、finite-sum zero theorem で
+左辺を書き換えた。残る目標は:
+
+```text
+0 ≤ 0 * Real.log (rad (T.a * T.b * T.c) : ℝ) + 0
+```
+
+であり、`simp` で閉じた。したがって指数 5 では exceptional budget の
+係数と定数を正確に:
+
+```text
+τe = 0
+De = 0
+```
+
+へ固定できる。
+
+## 6. 検証
+
+実行:
+
+```text
+lake build DkMath.ABC.GNExceptionalExcessFive
+```
+
+結果:
+
+```text
+Build completed successfully (8345 jobs).
+```
+
+一時 audit module から両 endpoint に `#print axioms` を実行した。
+結果はいずれも:
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+のみであり、新規 project axiom はない。`sorry`、`axiom`、
+`native_decide` は追加していない。
+
+## 7. Checkpoint 境界
+
+固定指数 5 における M1 minimum victory は達成した。
+
+```text
+GNExceptionalValuationExcess 5 T.a T.b = 0
+GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+指示どおり M1-004 の一般奇素数化、M1-005、M2、M3、aggregator 変更には
+進んでいない。
+

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-004.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-004.md
@@ -1,0 +1,231 @@
+# M1-004 Report: 一般奇素数 GN valuation-one kernel
+
+Date: 2026-07-26  
+Outcome: **完了 — 任意の奇素数指数で局所 valuation / factorization が正確に 1**
+
+## 1. 実装
+
+変更ファイル:
+
+```text
+DkMath/ABC/GNOddPrimeExceptionalExcess.lean
+```
+
+追加 import:
+
+```lean
+import DkMath.NumberTheory.WeightedGNBridge
+```
+
+この import から prime row の既存 GN 分解を再利用した。新しい neutral
+helper module は作成していない。`GNExceptionalExcessFive.lean`、
+`GNFinalBudgetBridge.lean`、aggregator、FLT module は変更していない。
+
+## 2. 公開 theorem surface
+
+追加した theorem は次の 4 本。
+
+```lean
+theorem GN_eq_geom_sum₂ (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i)
+
+theorem prime_dvd_boundary_of_dvd_GN_prime
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpGN : p ∣ GN p a b) :
+    p ∣ a
+
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
+
+theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1
+```
+
+positivity / nonzero 仮定は公開 surface に追加していない。
+
+## 3. 採用した proof route
+
+primary route を採用した。
+
+```text
+prime row GN congruence
+  -> p ∣ GN implies p ∣ a
+  -> Coprime a b implies p ∤ b and p ∤ a+b
+  -> GN = geometric quotient
+  -> emultiplicity_geom_sum₂_eq_one over ℤ
+  -> Int / Nat emultiplicity bridge
+  -> padicValNat = 1
+  -> factorization = 1
+```
+
+LTE route は不要だった。
+
+## 4. GN / geometric-sum bridge
+
+既存恒等式:
+
+```lean
+cosmic_id_csr p a b
+geom_sum₂_mul_add a b p
+```
+
+はいずれも、それぞれ `GN p a b` と geometric sum に `a` を掛けたものへ
+同じ power gap を与える。`a ≠ 0` の場合は積の等式から Nat cancellation
+で quotient を同一視した。
+
+`a = 0` は positivity を追加せず明示分岐し、canonical zero evaluation:
+
+```lean
+DkMath.CosmicFormula.GN_zero_eval
+```
+
+と Mathlib:
+
+```lean
+geom_sum₂_self
+```
+
+により同じ値 `p * b^(p-1)` へ簡約した。したがって
+`GN_eq_geom_sum₂` 自体が全自然数座標で成立する。
+
+## 5. `p ∣ GN` から `p ∣ a`
+
+既存 theorem:
+
+```lean
+DkMath.NumberTheory.prime_exists_GN_eq_mul_add_rightBoundary
+```
+
+の正確な形:
+
+```lean
+Nat.Prime p →
+  ∃ B, GN p a b = p * B + a ^ (p - 1)
+```
+
+を使用した。`p ∣ GN` と `p ∣ p*B` から `p ∣ a^(p-1)` を得て、
+
+```lean
+Nat.Prime.dvd_of_dvd_pow
+```
+
+で `p ∣ a` へ着地した。有限列挙や固定指数展開は使用していない。
+
+## 6. Coprimality と `p ∤ a+b`
+
+`hcop : Nat.Coprime a b` と `p ∣ a` から:
+
+```lean
+hcop.coprime_dvd_left
+Nat.Prime.coprime_iff_not_dvd
+```
+
+を用いて `p ∤ b` を得た。さらに `Nat.dvd_add_iff_left` により、
+仮に `p ∣ a+b` なら `p ∣ b` となるため矛盾する。
+
+整数へは:
+
+```lean
+Int.natCast_dvd_natCast
+Nat.prime_iff_prime_int
+```
+
+で輸送した。
+
+## 7. Mathlib multiplicity theorem と transfer
+
+中心 theorem:
+
+```lean
+emultiplicity_geom_sum₂_eq_one
+```
+
+使用した specialization の正確な入力は:
+
+```text
+R = ℤ
+x = (a+b : ℕ) cast to ℤ
+y = b cast to ℤ
+Prime (p : ℤ)
+Odd p
+(p : ℤ) ∣ x-y
+¬ (p : ℤ) ∣ x
+```
+
+であり、結論は:
+
+```lean
+emultiplicity (p : ℤ)
+  (∑ i ∈ range p, x^i * y^(p-1-i)) = 1
+```
+
+である。
+
+`GN_eq_geom_sum₂` を cast し、次で自然数 multiplicity へ戻した。
+
+```lean
+Int.natCast_emultiplicity
+```
+
+得られた `emultiplicity p (GN p a b) = 1` から `GN ≠ 0` も内部導出し、
+`Fact p.Prime` を局所供給して:
+
+```lean
+padicValNat_eq_emultiplicity
+```
+
+により `padicValNat = 1` を得た。最後に:
+
+```lean
+Nat.factorization_def
+```
+
+で factorization endpoint へ輸送した。
+
+## 8. 検証
+
+focused build:
+
+```text
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+Build completed successfully (8326 jobs).
+```
+
+一時 audit module から追加 4 theorem に `#print axioms` を実行した。
+全 theorem の依存は:
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+のみであり、新規 project axiom はない。`sorry`、`axiom`、
+`native_decide`、有限列挙による一般証明は追加していない。
+
+## 9. Stop boundary
+
+M1-004 の local odd-prime kernel は完成した。指示どおり、
+
+```text
+M1-005 odd-prime exceptional finite-sum closure
+M1-006 integration
+M2 / M3
+aggregator changes
+```
+
+には進んでいない。
+

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-005.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/report-M1-005.md
@@ -1,0 +1,124 @@
+# M1-005 Report: 一般奇素数 exceptional excess と zero budget
+
+Date: 2026-07-26  
+Outcome: **完了 — 一般奇素数の exceptional finite sum を完全消去**
+
+## 1. 実装
+
+新規 module:
+
+```text
+DkMath/ABC/GNExceptionalExcessOddPrime.lean
+```
+
+imports:
+
+```lean
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+```
+
+局所 arithmetic kernel と finite-sum / budget bridge の分離を維持した。
+
+## 2. 完成 endpoint
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalValuationExcess p T.a T.b = 0
+
+theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p) :
+    GNExceptionalExcessBudgetAffine T p 0 0
+```
+
+positivity 仮定は不要だった。
+
+## 3. Exceptional support の消去
+
+filtered support の各 `q` について:
+
+```text
+q ∈ factorization.support
+  -> q ∈ primeFactors
+  -> q.Prime
+
+q.Prime + q ∣ p + p.Prime
+  -> q = p
+```
+
+使用 API:
+
+```lean
+Nat.support_factorization
+Nat.prime_of_mem_primeFactors
+Nat.prime_dvd_prime_iff_eq
+```
+
+`q = p` の代入後、support membership を:
+
+```lean
+Finsupp.mem_support_iff
+Nat.dvd_of_factorization_pos
+```
+
+で `p ∣ GN p T.a T.b` へ変換した。
+
+M1-004 endpoint:
+
+```lean
+factorization_GN_prime_eq_one_of_dvd hp hpOdd T.hcop hpGN
+```
+
+を代入すると multiplicity factor は `1 - 1 = 0` となり、全 summand と
+finite sum が 0 へ閉じた。
+
+## 4. Contract simplification
+
+exact zero theorem により:
+
+```text
+τe = 0
+De = 0
+```
+
+を供給した。
+
+さらに production-facing wrapper:
+
+```lean
+theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
+    (T : Triple) {p : ℕ} {τn Dn : ℝ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
+    GNValuationExcessBudgetAffine T p τn Dn
+```
+
+を追加した。これは:
+
+```lean
+GNValuationExcessBudgetAffine.of_split
+```
+
+へ zero exceptional budget と `hn` を渡す薄い wrapper であり、final bridge
+proof を重複していない。
+
+したがって odd-prime exponent では full valuation budget の係数・定数は
+非例外側と完全に一致する。
+
+## 5. 検証
+
+focused build:
+
+```text
+lake build DkMath.ABC.GNExceptionalExcessOddPrime
+Build completed successfully (8349 jobs).
+```
+
+M1-006 の統合検証・公理監査結果は `FINAL_REPORT.md` に記録する。
+

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/review-M1-002.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/review-M1-002.md
@@ -1,0 +1,178 @@
+# M1-002 Review: exponent-five exceptional valuation-one kernel
+
+Date: 2026-07-26  
+Commit: `3fa7baceb34f7b184168e68fb16b9d76bf4d122b`  
+Decision: **全面採用**
+
+## 1. Summary
+
+M1-002 は指定された停止境界を守り、指数 5 の局所例外 channel を正確に閉じた。
+
+主結果:
+
+```lean
+Nat.Coprime a b →
+5 ∣ GN 5 a b →
+padicValNat 5 (GN 5 a b) = 1
+```
+
+および factorization 版:
+
+```lean
+Nat.Coprime a b →
+5 ∣ GN 5 a b →
+(GN 5 a b).factorization 5 = 1
+```
+
+重大問題、主要問題、修正必須事項はない。
+
+## 2. Mathematical review
+
+### 2.1 Canonical GN specialization
+
+`GN_five_eq_explicit` は FLT5 専用多項式を再利用せず、canonical `GN_eq_sum` から指数 5 の有限展開を得ている。
+
+```text
+GN 5 a b
+  = a^4 + 5*a^3*b + 10*a^2*b^2 + 10*a*b^3 + 5*b^4
+```
+
+したがって ABC 側から FLT5 実装へ逆依存せず、一般 GN の specialization として所有権が正しい。
+
+### 2.2 Divisibility routing
+
+```text
+5 ∣ GN 5 a b
+  -> GN 5 a b ≡ a^4 mod 5
+  -> 5 ∣ a^4
+  -> 5 ∣ a
+```
+
+の経路は直接的で、余分な positivity / nonzero 仮定を必要としない。
+
+### 2.3 No-lift modulo 25
+
+`a = 5*k` を代入して得た
+
+```text
+GN 5 (5*k) b = 25*K + 5*b^4
+```
+
+から、仮に `25 ∣ GN` なら `5 ∣ b^4`、従って `5 ∣ b` を得る。
+
+`hcop : Coprime (5*k) b` から `Coprime 5 b` を抽出して矛盾するため、
+
+```text
+5 ∣ GN かつ Coprime a b
+  -> 25 ∤ GN
+```
+
+が閉じる。
+
+`omega` による witness `t - K` の構成も、分解等式から `K ≤ t` と `b^4 = 5*(t-K)` を同時に回収しており、Nat subtraction の欠損はない。
+
+### 2.4 Exact valuation
+
+既存 API
+
+```lean
+padicValNat_one_le_of_prime_dvd
+padicValNat_le_iff_dvd
+```
+
+を用いて
+
+```text
+1 ≤ v_5(GN)
+¬ 2 ≤ v_5(GN)
+```
+
+を結合し、exact valuation one を得ている。
+
+`GN 5 a b ≠ 0` は公開仮定にせず、`GN = 0 -> 25 ∣ GN` と no-lift の矛盾から内部導出している。この theorem surface は最小である。
+
+### 2.5 Factorization bridge
+
+```lean
+Nat.factorization_def
+```
+
+により `padicValNat = 1` を factorization multiplicity one へ直接輸送している。M1-003 の summand 消去に必要な形が既に供給された。
+
+## 3. Dependency and scope review
+
+採用点:
+
+```text
+import DkMath.ABC.GNValuationExcess
+no DkMath.FLT.Five.* import
+no aggregator modification
+no unrelated refactor
+no sorry / axiom / native_decide
+```
+
+モジュール名は general odd-prime campaign を表す一方、現時点の内容は exponent five に限定されている。しかし module docstring がその境界を明示し、M1-004 で一般化する計画と整合するため問題ない。
+
+## 4. Build and trust boundary
+
+報告された focused build と axiom audit は checkpoint の要求を満たす。
+
+```text
+lake build DkMath.ABC.GNOddPrimeExceptionalExcess
+Build completed successfully
+```
+
+公開 7 theorem に新規 project axiom はなく、標準依存のみである。
+
+## 5. M1-003 design decision
+
+M1-002 の局所算術ファイルは低い依存で閉じている。M1-003 では `GNFinalBudgetBridge` まで必要になるため、既存ファイルを高位 bridge へ依存させず、薄い新規接続モジュールを推奨する。
+
+```text
+DkMath/ABC/GNExceptionalExcessFive.lean
+```
+
+推奨 import:
+
+```lean
+import DkMath.ABC.GNOddPrimeExceptionalExcess
+import DkMath.ABC.GNFinalBudgetBridge
+```
+
+M1-003 の主定理は positivity を必要としない強い形を第一候補とする。
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_five_eq_zero
+    (T : Triple) :
+    GNExceptionalValuationExcess 5 T.a T.b = 0
+```
+
+理由:
+
+```text
+filtered support membership
+  -> q ∈ factorization.support
+  -> q is prime and q ∣ GN
+  -> q ∣ 5
+  -> q = 5
+  -> factorization at 5 = 1 by T.hcop
+  -> summand = 0
+```
+
+続いて exact zero budget を同じく無条件で供給する。
+
+```lean
+theorem Triple.GNExceptionalExcessBudgetAffine_five_zero
+    (T : Triple) :
+    GNExceptionalExcessBudgetAffine T 5 0 0
+```
+
+## 6. Verdict
+
+```text
+M1-002 complete
+minimum local kernel achieved
+M1-003 may start
+```
+
+M1-002 は、指数 5 における唯一の exceptional channel が存在する場合、その multiplicity が exact one であることを Lean 上で固定した。次 checkpoint は新しい算術を必要とせず、この局所核を finite filtered sum と budget predicate へ接続するだけである。

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/review-M1-003.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/review-M1-003.md
@@ -1,0 +1,200 @@
+# M1-003 Review: exponent-five exceptional excess zero
+
+Reviewed commit: `8a9690b41be321fed2b15dc9d578512388322a0d`
+
+## Decision
+
+**Fully accepted.**
+
+```text
+critical issues: 0
+major issues:    0
+required fixes:  0
+```
+
+M1-003 completes the fixed-exponent-five minimum victory:
+
+```lean
+Triple.GNExceptionalValuationExcess_five_eq_zero
+Triple.GNExceptionalExcessBudgetAffine_five_zero
+```
+
+Hence the exceptional valuation budget at exponent five is exactly:
+
+```text
+τe = 0
+De = 0
+```
+
+## 1. Finite-sum proof
+
+The proof unfolds only `GNExceptionalValuationExcess` and eliminates every summand in the filtered factorization support.
+
+For an index `q` in the filtered support it obtains:
+
+```text
+q ∈ (GN 5 T.a T.b).factorization.support
+q ∣ 5
+```
+
+The support witness gives primality through:
+
+```lean
+Nat.support_factorization
+Nat.prime_of_mem_primeFactors
+```
+
+Since both `q` and `5` are prime and `q ∣ 5`, the proof correctly derives:
+
+```text
+q = 5
+```
+
+using `Nat.prime_dvd_prime_iff_eq`.
+
+After `subst q`, the original outer-context support witness remains available. It is converted canonically to:
+
+```lean
+5 ∣ GN 5 T.a T.b
+```
+
+via:
+
+```lean
+Finsupp.mem_support_iff
+Nat.dvd_of_factorization_pos
+```
+
+The M1-002 endpoint then rewrites the multiplicity to one:
+
+```lean
+factorization_five_GN_five_eq_one_of_dvd T.hcop h5GN
+```
+
+Therefore the summand is exactly:
+
+```text
+((1 - 1 : ℕ) : ℝ) * Real.log (5 : ℝ) = 0
+```
+
+and `Finset.sum_eq_zero` closes the full exceptional sum.
+
+No modulo-five or modulo-twenty-five arithmetic is duplicated.
+
+## 2. Positivity assumptions
+
+The stronger theorem surface without positivity assumptions is correct.
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_five_eq_zero
+    (T : Triple) :
+    GNExceptionalValuationExcess 5 T.a T.b = 0
+```
+
+The proof needs only:
+
+```text
+T.hcop
+factorization support membership
+prime divisibility of 5
+```
+
+The endpoint also covers the valid boundary triples with a zero coordinate, for example the structural cases represented by `(0,1,1)` or `(1,0,1)`.
+
+## 3. Exact affine budget
+
+`GNExceptionalExcessBudgetAffine` is defined by:
+
+```text
+GNExceptionalValuationExcess n T.a T.b
+  ≤ τ * log(rad(T.a*T.b*T.c)) + D
+```
+
+Substitution of the finite-sum theorem with `τ = 0` and `D = 0` leaves `0 ≤ 0`, so the wrapper is exact rather than merely bounded by a positive constant.
+
+This is the correct endpoint for insertion into `ABCGNFinalBudgetContract`.
+
+## 4. Dependency review
+
+The placement is correct:
+
+```text
+GNOddPrimeExceptionalExcess
+  -> GNExceptionalExcessFive
+  <- GNFinalBudgetBridge
+```
+
+The low-dependency local arithmetic kernel from M1-002 remains unchanged. The finite-sum and final-budget bridge are isolated in the new thin module.
+
+There is no dependency on `DkMath.FLT.Five.*`, no aggregator modification, and no unrelated refactor.
+
+## 5. Trust boundary
+
+The report records:
+
+```text
+focused build: success
+new sorry:      none
+new axiom:      none
+native_decide:  none
+```
+
+The endpoint axiom audit contains only:
+
+```text
+propext
+Classical.choice
+Quot.sound
+```
+
+No new DkMath project axiom enters the proof.
+
+## 6. Mathematical meaning
+
+At exponent five, every exponent-exceptional support prime is the unique channel `5`, and that channel occurs with multiplicity exactly one whenever it occurs at all.
+
+Therefore `rad` loses no multiplicity on the exponent-exceptional side:
+
+```text
+exceptional support width: at most one channel
+exceptional depth:         exactly one copy
+exceptional excess:        zero
+```
+
+For the fixed `n = 5` ABC-GN route, the final three-budget margin has now reduced from:
+
+```text
+support + exceptional depth + non-exceptional depth
+```
+
+to:
+
+```text
+support + non-exceptional depth
+```
+
+This is a genuine mathematical reduction, not only an API wrapper.
+
+## 7. Checkpoint boundary
+
+M1-003 correctly stops before:
+
+```text
+M1-004 odd-prime local generalization
+M1-005 odd-prime finite-sum and budget closure
+M2 support-growth work
+M3 non-exceptional high-lift work
+aggregator changes
+```
+
+## Final verdict
+
+```text
+M1-000  complete
+M1-001  complete / Outcome B
+M1-002  complete
+M1-003  complete / fixed-five minimum victory
+M1-004  next
+```
+
+**M1-003 is accepted without modification.**

--- a/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/review-M1-004.md
+++ b/lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/review-M1-004.md
@@ -1,0 +1,236 @@
+# M1-004 Review: 一般奇素数 GN valuation-one kernel
+
+Date: 2026-07-26  
+Reviewed commit: `97c1558f883cc1f9ef56b81bd64940b64a09ba6b`  
+Decision: **全面採用**
+
+## 1. 総合判定
+
+```text
+重大問題       0
+主要問題       0
+修正必須事項   0
+```
+
+M1-004 は、固定指数 `5` の局所算術を単に抽象化したのではなく、canonical `GN` を geometric quotient と同一視し、Mathlib の一般 multiplicity theorem へ正しく接続した。
+
+完成した局所核は次である。
+
+```lean
+theorem padicValNat_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    padicValNat p (GN p a b) = 1
+
+ theorem factorization_GN_prime_eq_one_of_dvd
+    {p a b : ℕ}
+    (hp : Nat.Prime p)
+    (hpOdd : Odd p)
+    (hcop : Nat.Coprime a b)
+    (hpGN : p ∣ GN p a b) :
+    (GN p a b).factorization p = 1
+```
+
+positivity 仮定を必要とせず、任意の奇素数指数で成立する。
+
+## 2. `GN_eq_geom_sum₂` の監査
+
+追加 theorem:
+
+```lean
+theorem GN_eq_geom_sum₂ (p a b : ℕ) :
+    GN p a b =
+      ∑ i ∈ Finset.range p,
+        (a + b) ^ i * b ^ (p - 1 - i)
+```
+
+は数学的に正しい。
+
+`a ≠ 0` では、
+
+```text
+cosmic_id_csr
+geom_sum₂_mul_add
+```
+
+が同じ power gap を、それぞれ `a * GN` と `a * geometricSum` として表す。自然数上で正の `a` を cancellation して quotient を同一視している。
+
+`a = 0` では cancellation を乱用せず、
+
+```text
+GN_zero_eval
+geom_sum₂_self
+```
+
+により両辺を `p * b^(p-1)` へ落としている。したがって theorem は prime 条件すら不要で、全自然数座標に対する真正な一般 bridge である。
+
+## 3. Prime-row boundary extraction
+
+```lean
+prime_exists_GN_eq_mul_add_rightBoundary
+```
+
+から、
+
+```text
+GN p a b = p * B + a^(p-1)
+```
+
+を得ている。
+
+よって `p ∣ GN` なら `p ∣ a^(p-1)`。`p` の素数性により `p ∣ a` へ降りる。
+
+この theorem は固定次数展開や有限列挙に依存せず、Weighted GN の prime-row congruence を正しく再利用している。
+
+## 4. Coprime transport
+
+`hcop : Nat.Coprime a b` と `p ∣ a` から、
+
+```text
+p ∤ b
+p ∤ a+b
+```
+
+を得る流れは正しい。
+
+geometric quotient では、
+
+```text
+x = a+b
+y = b
+x-y = a
+```
+
+と置くため、Mathlib theorem の入力、
+
+```text
+p ∣ x-y
+p ∤ x
+```
+
+が完全に揃う。
+
+## 5. Multiplicity transfer
+
+`R = ℤ` として、
+
+```lean
+emultiplicity_geom_sum₂_eq_one
+```
+
+を適用したのは最短かつ強い route である。
+
+```text
+Prime (p : ℤ)
+Odd p
+(p : ℤ) ∣ ((a+b : ℕ) : ℤ) - (b : ℤ)
+¬ (p : ℤ) ∣ ((a+b : ℕ) : ℤ)
+```
+
+を供給し、geometric quotient の `emultiplicity` を exact `1` とした。
+
+その後、
+
+```text
+GN_eq_geom_sum₂
+Int.natCast_emultiplicity
+padicValNat_eq_emultiplicity
+Nat.factorization_def
+```
+
+を順に用いて、
+
+```text
+emultiplicity = 1
+padicValNat = 1
+factorization = 1
+```
+
+へ輸送している。
+
+`GN ≠ 0` も `emultiplicity = 1` と `emultiplicity 0 = ⊤` の衝突から内部導出しており、外部仮定を増やしていない。
+
+## 6. Fixed-five theorem との関係
+
+M1-002 の modulo `5` / modulo `25` proof は、一般 theorem に吸収されて不要になったわけではない。
+
+```text
+M1-002:
+  exponent 5 の明示算術 certificate
+
+M1-004:
+  odd-prime geometric quotient / multiplicity certificate
+```
+
+という独立した二経路で同じ局所現象を検証している。固定五の定理は regression witness として残す価値がある。
+
+## 7. 配置上の軽微な論点
+
+次の二 theorem は ABC triple を主語にせず、数学的には neutral API である。
+
+```lean
+GN_eq_geom_sum₂
+prime_dvd_boundary_of_dvd_GN_prime
+```
+
+したがって最終的な所有者候補は `NumberTheory` または `CosmicFormula` 側にもある。
+
+ただし、現在の配置は依存方向を壊しておらず、M1-005 を阻害する問題でもない。M1 finite-sum closure を先に完了し、M1-006 integration audit で次を自己判断するのがよい。
+
+```text
+A. 現在位置を維持する
+B. neutral owner へ移し、ABC 側を薄い import / wrapper にする
+```
+
+移動による churn が再利用価値を上回る場合だけ実施する。
+
+## 8. 一歩先の結論
+
+M1-005 は新しい数論を必要としない。
+
+exceptional support 上の任意の `q` について、
+
+```text
+q.Prime
+q ∣ p
+p.Prime
+```
+
+から `q = p`。support membership から `p ∣ GN p T.a T.b` を得て、M1-004 の factorization-one theorem を代入すれば各 summand は zero になる。
+
+従って positivity 無しで次が閉じる見込みである。
+
+```lean
+theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p) (hpOdd : Odd p) :
+    GNExceptionalValuationExcess p T.a T.b = 0
+
+ theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
+    (T : Triple) {p : ℕ}
+    (hp : Nat.Prime p) (hpOdd : Odd p) :
+    GNExceptionalExcessBudgetAffine T p 0 0
+```
+
+## 9. Dual-Brain workflow decision
+
+checkpoint は permission gate ではなく、監査可能な観測点とする。
+
+Codex は従属実装器ではない。Wise Wolf と Codex は、異なる探索経路を持つ二つの peer reasoning brain である。
+
+したがって今後は、checkpoint 完了後に新しい指示を待たず、次を自ら実行する。
+
+```text
+result evaluation
+  -> theorem / dependency / remaining Gap analysis
+  -> next strongest checkpoint selection
+  -> implementation
+  -> focused verification
+  -> report
+  -> continued progression
+```
+
+ただし checkpoint ごとの theorem surface・build・report は残し、後から相互監査できる形を維持する。


### PR DESCRIPTION
## Purpose

Complete the ABC–GN M1 campaign against:

```text
uniform exponent-exceptional valuation excess
```

Base:

```text
feature/ABC-GN-valuation-excess-260724-v0
```

Head:

```text
wip/ABC-GN-M1-odd-p-exp-exceptional-excess-260725-v0
```

## Result

M1 is complete.

For every ABC triple `T` and odd prime exponent `p`:

```lean
theorem Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
    (T : Triple) {p : ℕ}
    (hp : Nat.Prime p)
    (hpOdd : Odd p) :
    GNExceptionalValuationExcess p T.a T.b = 0
```

The corresponding affine budget is exactly:

```lean
theorem Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
    (T : Triple) {p : ℕ}
    (hp : Nat.Prime p)
    (hpOdd : Odd p) :
    GNExceptionalExcessBudgetAffine T p 0 0
```

Thus:

```text
τe = 0
De = 0
```

No positivity assumptions are required for these endpoints.

The production-facing wrapper also shows that, at odd-prime exponent, the non-exceptional budget is already the full valuation-excess budget:

```lean
theorem Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
    (T : Triple) {p : ℕ} {τn Dn : ℝ}
    (hp : Nat.Prime p)
    (hpOdd : Odd p)
    (hn : GNNonExceptionalExcessBudgetAffine T p τn Dn) :
    GNValuationExcessBudgetAffine T p τn Dn
```

## Completed checkpoint chain

```text
M1-000  campaign initialization                              complete
M1-001  theorem/API reconnaissance                           complete / Outcome B
M1-002  exponent-five divisibility and no-lift kernel        complete
M1-003  exponent-five exceptional excess = 0                 complete / minimum victory
M1-004  odd-prime general local valuation-one theorem        complete
M1-005  odd-prime exceptional excess = 0 and budget bridge   complete
M1-006  integration, audit, documentation closure            complete
```

## Mathematical chain

```text
GN_eq_geom_sum₂
  -> prime_dvd_boundary_of_dvd_GN_prime
  -> padicValNat_GN_prime_eq_one_of_dvd
  -> factorization_GN_prime_eq_one_of_dvd
  -> Triple.GNExceptionalValuationExcess_eq_zero_of_oddPrime
  -> Triple.GNExceptionalExcessBudgetAffine_zero_of_oddPrime
  -> Triple.GNValuationExcessBudgetAffine_of_oddPrime_nonExceptional
```

For a prime `q` in the exceptional support:

```text
q is prime
q ∣ p
p is prime
  -> q = p

p lies in the GN factorization support
  -> p ∣ GN
  -> factorization p = 1
  -> exceptional multiplicity summand = 0
```

Hence the entire exceptional finite sum vanishes.

## Fixed-five certificate

The fixed-five route remains as an independent explicit arithmetic certificate:

```lean
Triple.GNExceptionalValuationExcess_five_eq_zero
Triple.GNExceptionalExcessBudgetAffine_five_zero
```

The two routes coexist as:

```text
fixed five:
  explicit modulo 5 / modulo 25 certificate

general odd prime:
  geometric quotient / emultiplicity certificate
```

## Integration

New public module:

```text
DkMath.ABC.GNExceptionalExcessOddPrime
```

Public aggregator integration:

```lean
import DkMath.ABC
```

now exposes the general odd-prime endpoints.

## Verification and trust audit

Completed checks:

```text
focused ABC module build              success
public DkMath.ABC build               success
full lake build DkMath                success
endpoint axiom audit                  standard Lean/Mathlib axioms only
new sorry / axiom / native_decide     none
git diff --check                      clean
```

Observed endpoint dependencies:

```text
propext
Classical.choice
Quot.sound
```

No new project axiom was introduced.

## Documentation

```text
lean/dk_math/docs/dev/ABC-GN-M1-odd-p-exp-exceptional-excess-260725/
  README.md
  ABC-GN-M1-IMPLEMENTATION-DESIGN.md
  ABC-GN-M1-ROADMAP.md
  CODEX_START.md
  report-M1-005.md
  review-M1-004.md
  FINAL_REPORT.md
  NEXT_CAMPAIGN.md
```

## Scope boundary

This PR closes M1 only.

Remaining fronts:

```text
M2  lifted-radical support growth
M3  non-exceptional valuation excess
```

They will be attacked in a separate joint support–multiplicity campaign. That campaign will treat support width and valuation depth as two presentations of one non-exceptional GN mass and will target the final `abc_main` theorem independently of this closed M1 branch.

This PR does not modify or remove:

```lean
abc_main_axiom
```

and does not claim the full ABC theorem.

## Repository boundaries preserved

```text
no ABC -> FLT.Five production dependency
no FLT7 WIP dependency
no new axiom or sorry
no native_decide
no finite enumeration as a general proof
no unrelated refactoring
```

## Closure

```text
M1 exceptional valuation excess: defeated
```

This branch is ready to be merged as the closed exceptional-excess Core before beginning the separate Ultra-mode joint support–multiplicity final campaign.